### PR TITLE
fix(markdown): remove margins of admonition-heading

### DIFF
--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -79,7 +79,7 @@
 
     h5 {
         color: rgb(var(--contrast-1100));
-        margin-bottom: 0;
+        margin: 0;
         font-size: pxToRem(15);
         padding: pxToRem(2) 0 0 var(--size-of-admonition-icon);
 


### PR DESCRIPTION
to save some space in the UI and make it look nicer

![image](https://user-images.githubusercontent.com/35954987/112967455-9303b300-914b-11eb-90cb-c5eac7802161.png)
