### PR TITLE
fix(playground): make example showcase text dark even in dark mode

### DIFF
--- a/src/components/playground/playground.scss
+++ b/src/components/playground/playground.scss
@@ -192,9 +192,16 @@ section.example {
 .show-case_component {
     padding: pxToRem(20);
     border-radius: pxToRem(14);
-    background-color: rgb(var(--kompendium-color-white));
-    box-shadow: var(--shadow-showcase);
+    background-color: rgb(var(--kompendium-contrast-100));
     border: 1px solid rgb(var(--kompendium-contrast-300));
+    box-shadow: var(--shadow-showcase);
+
+    @include in(dark-mode) {
+        // prevents dark mode to klick in for examples, because Lime Elements doesn't support dark mode yet
+        background-color: rgb(var(--kompendium-contrast-1700));
+        color: rgb(var(--kompendium-contrast-200));
+        border-color: transparent;
+    }
 }
 
 .debug {


### PR DESCRIPTION
fixes color problems like this one:

## before
![image](https://user-images.githubusercontent.com/35954987/118801203-0949a980-b8a1-11eb-8569-0cf915eb513c.png)


## after
![image](https://user-images.githubusercontent.com/35954987/118801156-fc2cba80-b8a0-11eb-93c4-e3476a581bae.png)
