### PR TITLE
In narrow mode, close the nav menu when clicking descendent-less item or clicking outside the menu

### DIFF
--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -17,6 +17,16 @@ header {
     }
 }
 
+.nav-panel-scrim {
+    display: none;
+    z-index: 99;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+}
+
 .nav-panel {
     transition: margin 0.2s ease;
     z-index: 100;
@@ -141,6 +151,12 @@ header {
 }
 
 @media (max-width: $break-point-small) {
+    .nav-panel-scrim {
+        &.display-nav-panel {
+            display: block;
+        }
+    }
+
     .nav-panel {
         margin-left: calc(var(--width-nav-panel) * -1);
 

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -223,9 +223,14 @@ header {
     }
 
     img {
+        visibility: hidden;
         transition: transform 0.2s ease;
         transform: scale(0.8);
         height: pxToRem(32);
+    }
+
+    &.has-children img {
+        visibility: visible;
     }
 }
 
@@ -289,7 +294,7 @@ header {
         }
     }
 
-    img {
+    .panel-link.has-children img {
         visibility: hidden;
     }
 

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -129,11 +129,12 @@ export class Navigation {
             chapters: true,
             'panel-list': true,
         };
+        const chapters = item.children || [];
         const anchorClassList = {
             'panel-link': true,
             active: this.isRouteActive(item.path),
+            'has-children': !!chapters.length,
         };
-        const chapters = item.children || [];
         const path = getAssetPath(
             '../collection/assets/icons/arrow-right-s-line.svg'
         );

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -137,10 +137,18 @@ export class Navigation {
         const path = getAssetPath(
             '../collection/assets/icons/arrow-right-s-line.svg'
         );
+        const anchorAdditionalProps: any = {};
+        if (!chapters.length) {
+            anchorAdditionalProps.onClick = this.toggleMenu;
+        }
 
         return (
             <li class="panel-item">
-                <a class={anchorClassList} href={'#' + item.path}>
+                <a
+                    class={anchorClassList}
+                    href={'#' + item.path}
+                    {...anchorAdditionalProps}
+                >
                     <img src={path} />
                     <span class="link-text">{item.title}</span>
                 </a>

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -1,11 +1,4 @@
-import {
-    Component,
-    h,
-    Prop,
-    State,
-    getAssetPath,
-    Element,
-} from '@stencil/core';
+import { Component, h, Prop, State, getAssetPath } from '@stencil/core';
 import { MenuItem } from '../../types';
 
 /**
@@ -44,8 +37,8 @@ export class Navigation {
     @State()
     private route = '';
 
-    @Element()
-    private host: HTMLKompendiumNavigationElement;
+    @State()
+    private displayNavPanel = false;
 
     constructor() {
         this.setRoute = this.setRoute.bind(this);
@@ -65,9 +58,22 @@ export class Navigation {
         this.route = location.hash.substr(1);
     }
 
-    public render(): HTMLElement {
-        return (
-            <nav class="nav-panel">
+    public render(): HTMLElement[] {
+        return [
+            <div
+                class={{
+                    'nav-panel-scrim': true,
+                    'display-nav-panel': this.displayNavPanel,
+                }}
+                onClick={this.toggleMenu}
+            ></div>,
+            <nav
+                class={{
+                    'nav-panel': true,
+                    'display-nav-panel': this.displayNavPanel,
+                }}
+                onClick={this.stopPropagationOfNavClick}
+            >
                 <a class="nav-panel__responsive-menu" onClick={this.toggleMenu}>
                     <span></span>
                     <span></span>
@@ -79,8 +85,8 @@ export class Navigation {
                     <kompendium-search index={this.index} />
                 </header>
                 {this.renderChapters(this.menu)}
-            </nav>
-        );
+            </nav>,
+        ];
     }
 
     private renderHeader() {
@@ -94,12 +100,7 @@ export class Navigation {
     }
 
     private toggleMenu = () => {
-        const panel = this.host.shadowRoot.querySelector('.nav-panel');
-        if (!panel) {
-            return;
-        }
-
-        panel.classList.toggle('display-nav-panel');
+        this.displayNavPanel = !this.displayNavPanel;
     };
 
     private renderChapters(menu: MenuItem[]) {
@@ -151,6 +152,10 @@ export class Navigation {
     private isRouteActive(route: string) {
         return this.route.startsWith(route);
     }
+
+    private stopPropagationOfNavClick = (event: MouseEvent) => {
+        event.stopPropagation();
+    };
 }
 
 // function hasContent(item: MenuItem) {


### PR DESCRIPTION
fix: #29

Bonus: only render chevrons for top-level items with children.