### PR TITLE
fix(typography): correct heading "sizes", start with `h1` and don't skip any

### DIFF
--- a/src/components/component/templates/events.tsx
+++ b/src/components/component/templates/events.tsx
@@ -14,9 +14,9 @@ export function EventList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Events
-        </h3>,
+        </h2>,
         ...events.map(renderEvent),
     ];
 }
@@ -43,7 +43,7 @@ function renderEvent(event: JsonDocsEvent) {
 
     return (
         <div class="props-events-layout">
-            <h4>{event.event}</h4>
+            <h3>{event.event}</h3>
             <kompendium-taglist tags={event.docsTags} />
             <div class="markdown-props">
                 <kompendium-markdown text={event.docs} />

--- a/src/components/component/templates/examples.tsx
+++ b/src/components/component/templates/examples.tsx
@@ -15,9 +15,9 @@ export function ExampleList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Examples
-        </h3>,
+        </h2>,
         examples.map(renderExample(schema)),
     ];
 }

--- a/src/components/component/templates/methods.tsx
+++ b/src/components/component/templates/methods.tsx
@@ -19,9 +19,9 @@ export function MethodList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Methods
-        </h3>,
+        </h2>,
         ...methods.map(renderMethod),
     ];
 }
@@ -36,7 +36,7 @@ function renderMethod(method: JsonDocsMethod) {
 
     return (
         <div class="methods-layout">
-            <h4 class="methods-title">{method.name}</h4>
+            <h3 class="methods-title">{method.name}</h3>
             <div class="methods-content">
                 <div>
                     <kompendium-markdown text={method.docs} />
@@ -59,7 +59,7 @@ function ParamList({ params }: { params: JsonDocMethodParameter[] }) {
         return;
     }
 
-    return [<h5>Parameters</h5>, ...params.map(renderParam)];
+    return [<h4>Parameters</h4>, ...params.map(renderParam)];
 }
 
 function renderParam(param: ParameterDescription) {
@@ -80,7 +80,7 @@ function renderParam(param: ParameterDescription) {
 
     return (
         <div>
-            <h6>{param.name}</h6>
+            <h5>{param.name}</h5>
             <kompendium-markdown text={param.docs} />
             <kompendium-proplist items={items} />
         </div>
@@ -95,7 +95,7 @@ function Returns({ value }: { value: JsonDocsMethodReturn }) {
     const type = '`' + value.type + '`';
 
     return [
-        <h5>Returns</h5>,
+        <h4>Returns</h4>,
         <kompendium-markdown text={value.docs} />,
         <kompendium-markdown text={type} />,
     ];

--- a/src/components/component/templates/props.tsx
+++ b/src/components/component/templates/props.tsx
@@ -14,9 +14,9 @@ export function PropertyList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Properties
-        </h3>,
+        </h2>,
         ...props.map(renderProperty),
     ];
 }
@@ -47,7 +47,7 @@ function renderProperty(property: JsonDocsProp) {
 
     return (
         <div class="props-events-layout">
-            <h4>{property.name}</h4>
+            <h3>{property.name}</h3>
             <kompendium-taglist tags={property.docsTags} />
             <div class="markdown-props">
                 <kompendium-markdown text={property.docs} />

--- a/src/components/component/templates/slots.tsx
+++ b/src/components/component/templates/slots.tsx
@@ -13,9 +13,9 @@ export function SlotList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Slots
-        </h3>,
+        </h2>,
         ...slots.map(renderSlot),
     ];
 }
@@ -23,7 +23,7 @@ export function SlotList({
 function renderSlot(slot: JsonDocsSlot) {
     return (
         <div>
-            <h4>{slot.name}</h4>
+            <h3>{slot.name}</h3>
             <kompendium-markdown text={slot.docs} />
         </div>
     );

--- a/src/components/component/templates/style.tsx
+++ b/src/components/component/templates/style.tsx
@@ -13,9 +13,9 @@ export function StyleList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Styles
-        </h3>,
+        </h2>,
         ...styles.map(renderStyle),
     ];
 }

--- a/src/components/type/templates/enum.tsx
+++ b/src/components/type/templates/enum.tsx
@@ -16,7 +16,7 @@ function MemberList({ members }: { members: EnumMember[] }): HTMLElement[] {
         return;
     }
 
-    return [<h3>Members</h3>, ...members.map(renderMember)];
+    return [<h2>Members</h2>, ...members.map(renderMember)];
 }
 
 function renderMember(member: EnumMember) {
@@ -29,7 +29,7 @@ function renderMember(member: EnumMember) {
 
     return (
         <div>
-            <h4>{member.name}</h4>
+            <h3>{member.name}</h3>
             <kompendium-markdown text={member.docs} />
             <kompendium-taglist tags={member.docsTags} />
             <kompendium-proplist items={items} />


### PR DESCRIPTION
re: #31

This does not yet fix #31, as I haven't found where the heading size for examples is set, but it does fix some other heading "size" inconsistencies. We might want to adjust the styling of h2 through h6, as most headings have become one step "bigger".