### PR TITLE
UI improvements

### DIFF
--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -50,7 +50,7 @@ header {
         overflow-y: auto;
 
         &:not(.chapters) {
-            padding: 0 pxToRem(12) pxToRem(32) pxToRem(4);
+            padding: 0 pxToRem(12) pxToRem(32) pxToRem(12);
         }
     }
 }
@@ -228,13 +228,18 @@ header {
 .panel-item {
     transition: opacity 0.2s ease;
     width: 100%;
+    border-radius: pxToRem(6);
+
+    &.active {
+        background-color: rgb(var(--kompendium-contrast-100), 0.5);
+    }
 }
 
 .panel-link {
     display: grid;
     grid: {
         auto-flow: column;
-        template-columns: pxToRem(20) 1fr;
+        template-columns: 1fr pxToRem(28);
     }
     line-height: pxToRem(28);
     color: rgb(var(--kompendium-contrast-900));
@@ -248,14 +253,14 @@ header {
 
     &.active {
         svg {
-            transform: rotate(90deg) scale(0.64);
+            transform: scale(0.64) rotate(-90deg);
         }
     }
 
     svg {
         visibility: hidden;
         transition: transform 0.2s ease;
-        transform: scale(0.64);
+        transform: scale(0.64) rotate(90deg);
         height: pxToRem(32);
     }
 
@@ -272,6 +277,10 @@ header {
 
 .chapters {
     height: 0;
+
+    > .panel-item {
+        padding-left: pxToRem(8);
+    }
 
     &.active {
         transition: height 0.2s ease;
@@ -318,7 +327,7 @@ header {
                 transition-delay: 0.19s;
             }
             &:last-child {
-                margin-bottom: pxToRem(28);
+                margin-bottom: pxToRem(8);
             }
         }
     }

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -50,7 +50,7 @@ header {
         overflow-y: auto;
 
         &:not(.chapters) {
-            padding: 0 pxToRem(4) pxToRem(32) pxToRem(4);
+            padding: 0 pxToRem(12) pxToRem(32) pxToRem(4);
         }
     }
 }
@@ -228,7 +228,6 @@ header {
 .panel-item {
     transition: opacity 0.2s ease;
     width: 100%;
-    padding-right: pxToRem(12);
 }
 
 .panel-link {
@@ -277,7 +276,6 @@ header {
 
     &.active {
         height: 100%;
-        padding-left: pxToRem(20);
 
         .panel-item {
             opacity: 1;
@@ -320,7 +318,7 @@ header {
                 transition-delay: 0.19s;
             }
             &:last-child {
-                margin-bottom: pxToRem(16);
+                margin-bottom: pxToRem(28);
             }
         }
     }
@@ -338,10 +336,6 @@ header {
 
             &:first-child {
                 margin-top: pxToRem(4);
-            }
-
-            &:last-child {
-                margin-bottom: pxToRem(8);
             }
         }
     }

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -272,9 +272,9 @@ header {
 
 .chapters {
     height: 0;
-    transition: height 0.2s ease;
 
     &.active {
+        transition: height 0.2s ease;
         height: 100%;
 
         .panel-item {

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -127,7 +127,7 @@ export class Navigation {
     }
 
     private renderMenuItem(item: MenuItem) {
-        const classList = {
+        const chapterClassList = {
             active: this.isRouteActive(item.path),
             chapters: true,
             'panel-list': true,
@@ -166,7 +166,9 @@ export class Navigation {
 
                     <span class="link-text">{item.title}</span>
                 </a>
-                <ul class={classList}>{chapters.map(this.renderMenuItem)}</ul>
+                <ul class={chapterClassList}>
+                    {chapters.map(this.renderMenuItem)}
+                </ul>
             </li>
         );
     }

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -127,6 +127,10 @@ export class Navigation {
     }
 
     private renderMenuItem(item: MenuItem) {
+        const itemClassList = {
+            active: this.isRouteActive(item.path),
+            'panel-item': true,
+        };
         const chapterClassList = {
             active: this.isRouteActive(item.path),
             chapters: true,
@@ -144,12 +148,13 @@ export class Navigation {
         }
 
         return (
-            <li class="panel-item">
+            <li class={itemClassList}>
                 <a
                     class={anchorClassList}
                     href={'#' + item.path}
                     {...anchorAdditionalProps}
                 >
+                    <span class="link-text">{item.title}</span>
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 24 24"
@@ -163,8 +168,6 @@ export class Navigation {
                             fill="currentColor"
                         />
                     </svg>
-
-                    <span class="link-text">{item.title}</span>
                 </a>
                 <ul class={chapterClassList}>
                     {chapters.map(this.renderMenuItem)}


### PR DESCRIPTION
<img width="660" alt="image" src="https://user-images.githubusercontent.com/35954987/180947959-20ee2945-d18f-43db-8922-8f0cfc4232ad.png">

There is too much space around items of the navigation panel. Both due to that and due to lack of other visual clues, it's a bit hard to notice what section of- or link within the navigation panel is selected. The only clue is the subtle blue text color of the selected item.

By putting more visual emphasis on those sections which are selected, and reducing the space around items, we could have a more clean and tidy navigation panel, as well as more clearly show which section and link within the section is active.

https://user-images.githubusercontent.com/35954987/180203135-cbf98b5c-5784-4c32-8388-cdce42d44a1d.mov

Also not that the arrows of expandable sections has moved to the right side.
