### PR TITLE
fix(colors): slightly lighten up the darkest `--contrast-` swatch

### DIFF
--- a/src/components/playground/playground.scss
+++ b/src/components/playground/playground.scss
@@ -194,10 +194,6 @@ section.example {
     background-color: rgb(var(--kompendium-contrast-100));
     border: 1px solid rgb(var(--kompendium-contrast-300));
     box-shadow: var(--shadow-showcase);
-
-    @include in(dark-mode) {
-        background-color: rgb(var(--kompendium-contrast-200));
-    }
 }
 
 .debug {

--- a/src/style/colors.scss
+++ b/src/style/colors.scss
@@ -28,7 +28,7 @@
     --kompendium-contrast-1400: 39, 39, 57; // #272739
     --kompendium-contrast-1500: 35, 35, 53; // #232335
     --kompendium-contrast-1600: 25, 25, 44; // #19192c
-    --kompendium-contrast-1700: 0, 0, 0; // #000
+    --kompendium-contrast-1700: 20, 20, 37; // #141425
 
     // Colors swatches that get slightly dimmer in dark mode
     --kompendium-color-red-light: 229, 115, 115; // #e57373;
@@ -47,7 +47,7 @@
     --kompendium-color-orange-default: 255, 152, 0; // #ff9800
 
     @include in(dark-mode) {
-        --kompendium-contrast-100: 0, 0, 0; // #000
+        --kompendium-contrast-100: 20, 20, 37; // #141425
         --kompendium-contrast-200: 25, 25, 44; // #19192c
         --kompendium-contrast-300: 35, 35, 53; // #232335
         --kompendium-contrast-400: 39, 39, 57; // #272739

--- a/src/style/typography.scss
+++ b/src/style/typography.scss
@@ -1,4 +1,5 @@
 @import './functions.scss';
+@import './mixins.scss';
 
 body {
 }
@@ -148,10 +149,20 @@ kbd {
     line-height: normal;
     padding: pxToRem(2) pxToRem(8);
     margin: 0 pxToRem(4);
-    border-radius: pxToRem(4);
     box-shadow: var(--kompendium-button-shadow-normal),
         0 #{pxToRem(0.5)} #{pxToRem(3.5)} 0
             rgba(var(--kompendium-contrast-100), 0.5) inset;
-    border: solid rgba(var(--kompendium-contrast-600), 0.8);
-    border-width: 0 pxToRem(1) pxToRem(2) pxToRem(1);
+
+    border: {
+        radius: pxToRem(4);
+        style: solid;
+        color: rgba(var(--kompendium-contrast-600), 0.8);
+        width: 0 1px pxToRem(2) 1px;
+    }
+
+    @include in(dark-mode) {
+        background-color: rgb(var(--kompendium-contrast-200));
+        color: rgb(var(--kompendium-contrast-1100));
+        border-color: rgba(var(--kompendium-contrast-500), 0.8);
+    }
 }


### PR DESCRIPTION
Previously, the `--kompendium-contrast-1700` in the `light` color-scheme, and `--kompendium-contrast-100` in the `dark` color-scheme were rendered fully black, equivalent of `rgb(0,0,0)`.
We had to change make it lighter to improve the color palette, because:
1. We already have a swatch for fully black, with a CSS variable called `--kompendium-color-black`.
1. Having these darkest `--contrast-` swatches render fully black makes it impossible to
visualize shadows or other black elements on it. Since this swatch is intended to be used for UI elements, it is important that it provides a level of safety as well, so in case any fully black element such as a piece of text that is hardcoded to be black is placed on it, the user can still have a chance to see it.