### PR TITLE
ci(release.yml): specify semantic-release version to use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       - run: npm run build
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
+        with:
+            semantic_version: 17.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The release workflow on `master` was failing due to some problem with semantic-release:

<img width="1044" alt="image" src="https://user-images.githubusercontent.com/154725/211834252-d51783df-38f2-4fee-8a9e-4284b4242b49.png">

This has been fixed by specifying which semantic-release version to use.