### PR TITLE
fix(style): allow long `<code />` blocks to render in multi lines

### DIFF
--- a/src/components/proplist/proplist.scss
+++ b/src/components/proplist/proplist.scss
@@ -22,7 +22,7 @@ code {
     border: 1px solid rgba(var(--kompendium-contrast-1100), 0.1);
     padding: 0.125rem 0.3125rem;
     margin: 0 0.125rem;
-    white-space: nowrap;
+    white-space: pre-wrap;
     color: rgb(var(--kompendium-contrast-1100));
 }
 
@@ -30,7 +30,7 @@ pre {
     > code {
         display: block;
         padding: 0.625rem 0.6375rem;
-        white-space: pre;
+        white-space: pre-wrap;
     }
 }
 

--- a/src/style/global-layout-rules.scss
+++ b/src/style/global-layout-rules.scss
@@ -128,7 +128,7 @@ kompendium-playground {
         border: 1px solid rgba(var(--kompendium-contrast-1100), 0.1);
 
         font-size: pxToRem(11);
-        white-space: nowrap;
+        white-space: pre-wrap;
         color: rgb(var(--kompendium-contrast-1100));
 
         padding: 0.125rem 0.3125rem;


### PR DESCRIPTION
To prevent broken UI and sideways scrolling in the page.

fix https://github.com/jgroth/kompendium/issues/112