### PR TITLE
feat(examples): enable consumers to supply props for example components

### DIFF
--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -2,6 +2,7 @@ import { Component, h, State, Prop, Watch } from '@stencil/core';
 import { KompendiumData, KompendiumDocument } from '../../types';
 import { setTypes } from '../markdown/markdown-types';
 import Fuse from 'fuse.js';
+import { PropsFactory } from '../playground/playground.types';
 
 @Component({
     tag: 'kompendium-app',
@@ -14,6 +15,12 @@ export class App {
      */
     @Prop()
     public path = '/kompendium.json';
+
+    /**
+     * Factory for creating props for example components
+     */
+    @Prop()
+    public examplePropsFactory?: PropsFactory;
 
     @State()
     public data: KompendiumData;
@@ -113,6 +120,8 @@ export class App {
                                 componentProps={{
                                     docs: this.data.docs,
                                     schemas: this.data.schemas,
+                                    examplePropsFactory:
+                                        this.examplePropsFactory,
                                 }}
                             />
                             <stencil-route

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -12,6 +12,7 @@ import { SlotList } from './templates/slots';
 import { StyleList } from './templates/style';
 import { ExampleList } from './templates/examples';
 import negate from 'lodash/negate';
+import { PropsFactory } from '../playground/playground.types';
 
 @Component({
     tag: 'kompendium-component',
@@ -36,6 +37,12 @@ export class KompendiumComponent {
      */
     @Prop()
     public match: MatchResults;
+
+    /**
+     * Factory for creating props for example components
+     */
+    @Prop()
+    public examplePropsFactory: PropsFactory;
 
     @Element()
     private host: HTMLKompendiumComponentElement;
@@ -110,6 +117,7 @@ export class KompendiumComponent {
                 examples={examples}
                 id={this.getId('examples')}
                 schema={schema}
+                propsFactory={this.examplePropsFactory}
             />,
             <PropertyList
                 props={component.props}

--- a/src/components/component/templates/examples.tsx
+++ b/src/components/component/templates/examples.tsx
@@ -1,14 +1,17 @@
 import { JsonDocsComponent, JsonDocsTag } from '@stencil/core/internal';
 import { h } from '@stencil/core';
+import { PropsFactory } from '../../playground/playground.types';
 
 export function ExampleList({
     examples,
     id,
     schema,
+    propsFactory,
 }: {
     id: string;
     examples: JsonDocsComponent[];
     schema: Record<string, any>;
+    propsFactory?: PropsFactory;
 }): HTMLElement[] {
     if (!examples.length) {
         return;
@@ -18,13 +21,20 @@ export function ExampleList({
         <h3 class="docs-layout-section-heading" id={id}>
             Examples
         </h3>,
-        examples.map(renderExample(schema)),
+        examples.map(renderExample(schema, propsFactory)),
     ];
 }
 
 const renderExample =
-    (schema: Record<string, any>) => (example: JsonDocsComponent) => {
-        return <kompendium-playground component={example} schema={schema} />;
+    (schema: Record<string, any>, factory: PropsFactory) =>
+    (example: JsonDocsComponent) => {
+        return (
+            <kompendium-playground
+                component={example}
+                schema={schema}
+                propsFactory={factory}
+            />
+        );
     };
 
 export const isExampleTag =

--- a/src/components/playground/playground.tsx
+++ b/src/components/playground/playground.tsx
@@ -2,6 +2,7 @@ import { Component, h, Host, Prop, State } from '@stencil/core';
 import { JsonDocsComponent } from '@stencil/core/internal';
 import { JsonDocsSource } from '../../kompendium/source';
 import { Theme, THEME_EVENT_NAME } from '../darkmode-switch/types';
+import { PropsFactory } from './playground.types';
 
 @Component({
     tag: 'kompendium-playground',
@@ -20,6 +21,14 @@ export class Playground {
      */
     @Prop()
     public schema: Record<string, any>;
+
+    /**
+     * Factory for creating props for example components
+     *
+     * @returns {Record<string, unknown>} props
+     */
+    @Prop()
+    public propsFactory?: PropsFactory = () => ({});
 
     @State()
     private activeTab: string;
@@ -86,8 +95,10 @@ export class Playground {
     private renderResult() {
         const ExampleComponent = this.component.tag;
         const text = '##### ' + this.component.docs;
+        const factory = this.propsFactory;
         const props = {
             schema: this.schema,
+            ...factory(ExampleComponent),
         };
 
         return (

--- a/src/components/playground/playground.types.ts
+++ b/src/components/playground/playground.types.ts
@@ -1,0 +1,1 @@
+export type PropsFactory = (name: string) => Record<string, unknown>;


### PR DESCRIPTION
This will enable consumers to supply props for example components. A props factory can be given to the root `kompendium-app` component which will be used when rendering all example components. The factory will be given the name of the example component that is being rendered.