### PR TITLE
fix(markdown): avoid "TypeError: Cannot read properties of undefined (reading toString)"

### DIFF
--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -33,7 +33,8 @@ export class Markdown {
     private async renderMarkdown() {
         const types = getTypes();
         const file = await markdownToHtml(this.text, types);
-        this.host.shadowRoot.querySelector('#root').innerHTML = file.toString();
+        this.host.shadowRoot.querySelector('#root').innerHTML =
+            file?.toString();
     }
 
     render(): HTMLElement {


### PR DESCRIPTION
The markdown component is logging a TypeError on basically every page in the Lime Elements docs:

<img width="858" alt="image" src="https://github.com/user-attachments/assets/b0f70360-b939-425e-9acb-98510ab888e6">

This fix avoids that, which will help us focus on any real errors that might occur.