### PR TITLE
chore(package-lock.json): automatic update by `npm install`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "kompendium",
       "version": "0.14.2",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
The `package-lock.json` is updated with this line every time you run `npm install`, which is a little bit annoying. If we commit the change, it won't be a change anymore 😄