### PR TITLE
feat(component): table of contents and anchor links on docs pages

### DIFF
--- a/src/components/anchor/anchor.scss
+++ b/src/components/anchor/anchor.scss
@@ -1,0 +1,30 @@
+:host {
+    display: inline;
+}
+
+.anchor {
+    display: inline;
+    margin-left: 0.25em;
+
+    color: rgb(var(--kompendium-contrast-700));
+    text-decoration: none;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+
+    opacity: var(--kompendium-anchor-opacity, 0);
+    transition:
+        opacity 0.2s ease,
+        color 0.2s ease;
+
+    &:hover,
+    &:focus-visible {
+        color: rgb(var(--kompendium-color-blue-default));
+        opacity: 1;
+    }
+
+    &.active {
+        color: rgb(var(--kompendium-color-blue-default));
+        opacity: 1;
+    }
+}

--- a/src/components/anchor/anchor.tsx
+++ b/src/components/anchor/anchor.tsx
@@ -1,0 +1,77 @@
+import { Component, h, Prop, State } from '@stencil/core';
+import { anchorHref, currentRoute } from '../component/anchors';
+import { getAnchorId } from '../anchor-scroll';
+
+/**
+ * Inline paragraph-link (¶) placed next to a heading. Picks up the parent
+ * heading's font-size, stays hidden until the heading is hovered, and
+ * highlights persistently when its slug matches the current URL anchor.
+ * @private
+ */
+@Component({
+    tag: 'kompendium-anchor',
+    styleUrl: 'anchor.scss',
+    shadow: true,
+})
+export class Anchor {
+    /**
+     * Slug used as the URL anchor fragment and scroll target.
+     */
+    @Prop()
+    public slug: string;
+
+    /**
+     * Human-readable label for the target, used for the aria-label.
+     */
+    @Prop()
+    public label: string;
+
+    @State()
+    private active = false;
+
+    constructor() {
+        this.handleHashChange = this.handleHashChange.bind(this);
+    }
+
+    public connectedCallback(): void {
+        this.updateActive();
+        window.addEventListener('hashchange', this.handleHashChange);
+    }
+
+    public disconnectedCallback(): void {
+        window.removeEventListener('hashchange', this.handleHashChange);
+    }
+
+    public render(): HTMLElement {
+        return (
+            <a
+                class={{ anchor: true, active: this.active }}
+                href={anchorHref(this.slug)}
+                aria-label={`Link to ${this.label}`}
+                onClick={this.handleClick}
+            >
+                ¶
+            </a>
+        );
+    }
+
+    private handleClick = (event: MouseEvent): void => {
+        if (!this.active) {
+            return;
+        }
+
+        event.preventDefault();
+        const url = new URL(window.location.href);
+        url.hash = currentRoute();
+        history.replaceState(history.state, '', url);
+        this.updateActive();
+    };
+
+    private handleHashChange(): void {
+        this.updateActive();
+    }
+
+    private updateActive(): void {
+        this.active = getAnchorId() === this.slug;
+    }
+}

--- a/src/components/component/anchors.ts
+++ b/src/components/component/anchors.ts
@@ -15,6 +15,20 @@ export const SECTION_SLUGS = {
 export type SectionSlug = (typeof SECTION_SLUGS)[keyof typeof SECTION_SLUGS];
 
 /**
+ * Return the first non-empty line of a text blob, trimmed. Returns an
+ * empty string if no non-empty line is found.
+ * @param {string} text the input text
+ * @returns {string} the first non-empty line
+ */
+export function firstLine(text: string): string {
+    const found = (text || '')
+        .split('\n')
+        .find((line) => line.trim().length > 0);
+
+    return found ? found.trim() : '';
+}
+
+/**
  * Derive an anchor id for an example component from its title (first line
  * of its docs). Falls back to the example's tag if no title is available.
  * @param {string} docs the example's docs text
@@ -22,10 +36,7 @@ export type SectionSlug = (typeof SECTION_SLUGS)[keyof typeof SECTION_SLUGS];
  * @returns {string} the anchor id to use in the URL hash
  */
 export function exampleAnchorId(docs: string, fallbackTag: string): string {
-    const title = (docs || '').split('\n')[0].trim();
-    const slug = title ? slugify(title) : '';
-
-    return slug || slugify(fallbackTag);
+    return slugify(firstLine(docs)) || slugify(fallbackTag);
 }
 
 /**

--- a/src/components/component/anchors.ts
+++ b/src/components/component/anchors.ts
@@ -84,3 +84,24 @@ export function slugify(name: string): string {
 export function entrySlug(sectionSlug: string, name: string): string {
     return `${sectionSlug}-${slugify(name)}`;
 }
+
+/**
+ * Compute unique anchor ids for a list of example components, appending
+ * `-2`, `-3`, ... suffixes when two examples would otherwise collide on
+ * the same slug (e.g. two examples share a title).
+ * @param {Array<{docs: string; tag: string}>} examples the examples in render order
+ * @returns {string[]} unique slugs in the same order
+ */
+export function uniqueExampleSlugs(
+    examples: Array<{ docs: string; tag: string }>,
+): string[] {
+    const counts = new Map<string, number>();
+
+    return examples.map((example) => {
+        const base = exampleAnchorId(example.docs, example.tag);
+        const count = counts.get(base) || 0;
+        counts.set(base, count + 1);
+
+        return count === 0 ? base : `${base}-${count + 1}`;
+    });
+}

--- a/src/components/component/anchors.ts
+++ b/src/components/component/anchors.ts
@@ -1,0 +1,75 @@
+/**
+ * Slug identifiers used by the table-of-contents and URL anchors on the
+ * component docs page. Kept separate so the component and its templates
+ * can share the same strings.
+ */
+export const SECTION_SLUGS = {
+    examples: 'examples',
+    properties: 'properties',
+    events: 'events',
+    methods: 'methods',
+    slots: 'slots',
+    styles: 'styles',
+} as const;
+
+export type SectionSlug = (typeof SECTION_SLUGS)[keyof typeof SECTION_SLUGS];
+
+/**
+ * Derive an anchor id for an example component from its title (first line
+ * of its docs). Falls back to the example's tag if no title is available.
+ * @param {string} docs the example's docs text
+ * @param {string} fallbackTag tag to slugify if the docs have no title
+ * @returns {string} the anchor id to use in the URL hash
+ */
+export function exampleAnchorId(docs: string, fallbackTag: string): string {
+    const title = (docs || '').split('\n')[0].trim();
+    const slug = title ? slugify(title) : '';
+
+    return slug || slugify(fallbackTag);
+}
+
+/**
+ * Read the current route part of the URL hash, stripping any trailing
+ * `#fragment` anchor.
+ * @returns {string} the route, without leading `#`
+ */
+export function currentRoute(): string {
+    const hash = window.location.hash.replace(/^#/, '');
+    const separatorIndex = hash.indexOf('#');
+
+    return separatorIndex === -1 ? hash : hash.substring(0, separatorIndex);
+}
+
+/**
+ * Build an `href` that preserves the current route and adds a secondary
+ * `#slug` anchor, e.g. `#/component/my-component#basic-example`.
+ * @param {string} slug the anchor id to link to
+ * @returns {string} the full href value
+ */
+export function anchorHref(slug: string): string {
+    return `#${currentRoute()}#${slug}`;
+}
+
+/**
+ * Turn an arbitrary identifier (camelCase, CSS custom property, etc.) into
+ * a URL-safe slug.
+ * @param {string} name the identifier to slugify
+ * @returns {string} the slugified identifier
+ */
+export function slugify(name: string): string {
+    return name
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Build a slug for an entry nested under a section, e.g. `properties-value`.
+ * @param {string} sectionSlug the section slug
+ * @param {string} name the entry name
+ * @returns {string} the combined slug
+ */
+export function entrySlug(sectionSlug: string, name: string): string {
+    return `${sectionSlug}-${slugify(name)}`;
+}

--- a/src/components/component/component.scss
+++ b/src/components/component/component.scss
@@ -16,3 +16,19 @@
         max-width: functions.pxToRem(960);
     }
 }
+
+.section-anchor {
+    display: block;
+    height: 0;
+    width: 0;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.docs-layout-section-heading:hover,
+.props-events-layout h4:hover,
+.methods-title:hover,
+.styles-title:hover,
+.docs h4:hover {
+    --kompendium-anchor-opacity: 1;
+}

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -22,8 +22,8 @@ import {
 import {
     SECTION_SLUGS,
     entrySlug,
-    exampleAnchorId,
     firstLine,
+    uniqueExampleSlugs,
 } from './anchors';
 import { TocEntry } from '../toc/toc.types';
 
@@ -195,13 +195,14 @@ function buildTocEntries(
 
     const resolvedExamples = examples.filter(Boolean);
     if (resolvedExamples.length) {
+        const slugs = uniqueExampleSlugs(resolvedExamples);
         entries.push({
             id: SECTION_SLUGS.examples,
             title: 'Examples',
             collapsible: true,
             defaultExpanded: true,
-            children: resolvedExamples.map((example) => {
-                const id = exampleAnchorId(example.docs, example.tag);
+            children: resolvedExamples.map((example, index) => {
+                const id = slugs[index];
                 const title = exampleTitle(example) || prettifyTag(id);
 
                 return { id: id, title: title };

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -97,7 +97,7 @@ export class KompendiumComponent {
     public render(): HTMLElement {
         const tag = this.match.params.name;
         const component = findComponent(tag, this.docs);
-        const examples = findExamples(component, this.docs);
+        const examples = findExamples(component, this.docs).filter(Boolean);
 
         return (
             <article class="component">
@@ -193,15 +193,14 @@ function buildTocEntries(
 ): TocEntry[] {
     const entries: TocEntry[] = [];
 
-    const resolvedExamples = examples.filter(Boolean);
-    if (resolvedExamples.length) {
-        const slugs = uniqueExampleSlugs(resolvedExamples);
+    if (examples.length) {
+        const slugs = uniqueExampleSlugs(examples);
         entries.push({
             id: SECTION_SLUGS.examples,
             title: 'Examples',
             collapsible: true,
             defaultExpanded: true,
-            children: resolvedExamples.map((example, index) => {
+            children: examples.map((example, index) => {
                 const id = slugs[index];
                 const title = exampleTitle(example) || prettifyTag(id);
 

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -19,7 +19,12 @@ import {
     scrollToAnchor,
     scrollToElement,
 } from '../anchor-scroll';
-import { SECTION_SLUGS, entrySlug, exampleAnchorId } from './anchors';
+import {
+    SECTION_SLUGS,
+    entrySlug,
+    exampleAnchorId,
+    firstLine,
+} from './anchors';
 import { TocEntry } from '../toc/toc.types';
 
 @Component({
@@ -274,9 +279,7 @@ function collapsibleSection(
 }
 
 function exampleTitle(example: JsonDocsComponent): string {
-    const firstLine = (example.docs || '').split('\n')[0];
-
-    return firstLine.trim();
+    return firstLine(example.docs);
 }
 
 function prettifyTag(slug: string): string {

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -13,7 +13,14 @@ import { StyleList } from './templates/style';
 import { ExampleList } from './templates/examples';
 import negate from 'lodash/negate';
 import { PropsFactory } from '../playground/playground.types';
-import { getRoute, scrollToElement } from '../anchor-scroll';
+import {
+    getAnchorId,
+    getRoute,
+    scrollToAnchor,
+    scrollToElement,
+} from '../anchor-scroll';
+import { SECTION_SLUGS, entrySlug, exampleAnchorId } from './anchors';
+import { TocEntry } from '../toc/toc.types';
 
 @Component({
     tag: 'kompendium-component',
@@ -63,39 +70,49 @@ export class KompendiumComponent {
     }
 
     protected componentDidLoad(): void {
-        const route = getRoute().split('#')[0];
-        scrollToElement(this.host.shadowRoot, route);
+        scrollToAnchor(this.host.shadowRoot);
     }
 
     protected componentDidUpdate(): void {
         if (this.scrollToOnNextUpdate) {
-            const route = this.scrollToOnNextUpdate.split('#')[0];
-            scrollToElement(this.host.shadowRoot, route);
+            scrollToElement(this.host.shadowRoot, this.scrollToOnNextUpdate);
             this.scrollToOnNextUpdate = null;
         }
     }
 
     private handleRouteChange() {
-        this.scrollToOnNextUpdate = getRoute().split('#')[0];
+        this.scrollToOnNextUpdate = this.getScrollTargetId();
+        scrollToAnchor(this.host.shadowRoot);
+    }
+
+    private getScrollTargetId(): string | null {
+        return getAnchorId() || getRoute().split('#')[0] || null;
     }
 
     public render(): HTMLElement {
         const tag = this.match.params.name;
         const component = findComponent(tag, this.docs);
+        const examples = findExamples(component, this.docs);
 
         return (
             <article class="component">
                 <section class="docs">
-                    {this.renderDocs(tag, component)}
+                    {this.renderDocs(tag, component, examples)}
                 </section>
+                <kompendium-toc
+                    entries={buildTocEntries(component, examples)}
+                />
             </article>
         );
     }
 
-    private renderDocs(tag: string, component: JsonDocsComponent) {
+    private renderDocs(
+        tag: string,
+        component: JsonDocsComponent,
+        examples: JsonDocsComponent[],
+    ) {
         let title = tag.split('-').slice(1).join(' ');
         title = title[0].toLocaleUpperCase() + title.slice(1);
-        const examples = findExamples(component, this.docs);
         const tags = component.docsTags
             .filter(negate(isTag('slot')))
             .filter(negate(isTag('exampleComponent')));
@@ -108,20 +125,35 @@ export class KompendiumComponent {
             <ExampleList
                 examples={examples}
                 id={this.getId('examples')}
+                slugId={SECTION_SLUGS.examples}
                 schema={schema}
                 propsFactory={this.examplePropsFactory}
             />,
             <PropertyList
                 props={component.props}
                 id={this.getId('properties')}
+                slugId={SECTION_SLUGS.properties}
             />,
-            <EventList events={component.events} id={this.getId('events')} />,
+            <EventList
+                events={component.events}
+                id={this.getId('events')}
+                slugId={SECTION_SLUGS.events}
+            />,
             <MethodList
                 methods={component.methods}
                 id={this.getId('methods')}
+                slugId={SECTION_SLUGS.methods}
             />,
-            <SlotList slots={component.slots} id={this.getId('slots')} />,
-            <StyleList styles={component.styles} id={this.getId('styles')} />,
+            <SlotList
+                slots={component.slots}
+                id={this.getId('slots')}
+                slugId={SECTION_SLUGS.slots}
+            />,
+            <StyleList
+                styles={component.styles}
+                id={this.getId('styles')}
+                slugId={SECTION_SLUGS.styles}
+            />,
         ];
     }
 
@@ -149,3 +181,117 @@ const findComponentByTag = (docs: JsonDocs) => (tag: JsonDocsTag) => {
 const isTag = (name: string) => (tag: JsonDocsTag) => {
     return tag.name === name;
 };
+
+function buildTocEntries(
+    component: JsonDocsComponent,
+    examples: JsonDocsComponent[],
+): TocEntry[] {
+    const entries: TocEntry[] = [];
+
+    const resolvedExamples = examples.filter(Boolean);
+    if (resolvedExamples.length) {
+        entries.push({
+            id: SECTION_SLUGS.examples,
+            title: 'Examples',
+            collapsible: true,
+            defaultExpanded: true,
+            children: resolvedExamples.map((example) => {
+                const id = exampleAnchorId(example.docs, example.tag);
+                const title = exampleTitle(example) || prettifyTag(id);
+
+                return { id: id, title: title };
+            }),
+        });
+    }
+
+    if (component.props?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.properties,
+                'Properties',
+                component.props.map((prop) => prop.name),
+            ),
+        );
+    }
+
+    if (component.events?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.events,
+                'Events',
+                component.events.map((event) => event.event),
+            ),
+        );
+    }
+
+    if (component.methods?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.methods,
+                'Methods',
+                component.methods.map((method) => method.name),
+            ),
+        );
+    }
+
+    if (component.slots?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.slots,
+                'Slots',
+                component.slots.map((slot) => slot.name),
+            ),
+        );
+    }
+
+    if (component.styles?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.styles,
+                'Styles',
+                component.styles.map((style) => style.name),
+            ),
+        );
+    }
+
+    return entries;
+}
+
+function collapsibleSection(
+    sectionSlug: string,
+    title: string,
+    names: string[],
+): TocEntry {
+    return {
+        id: sectionSlug,
+        title: title,
+        collapsible: true,
+        children: names.map((name) => ({
+            id: entrySlug(sectionSlug, name),
+            title: name,
+        })),
+    };
+}
+
+function exampleTitle(example: JsonDocsComponent): string {
+    const firstLine = (example.docs || '').split('\n')[0];
+
+    return firstLine.trim();
+}
+
+function prettifyTag(slug: string): string {
+    if (!slug) {
+        return slug;
+    }
+
+    const words = slug.split('-').filter(Boolean);
+    if (!words.length) {
+        return slug;
+    }
+
+    return (
+        words[0][0].toLocaleUpperCase() +
+        words[0].substring(1) +
+        (words.length > 1 ? ' ' + words.slice(1).join(' ') : '')
+    );
+}

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -25,6 +25,7 @@ import {
     firstLine,
     uniqueExampleSlugs,
 } from './anchors';
+import { slotDisplayName } from './slots';
 import { TocEntry } from '../toc/toc.types';
 
 @Component({
@@ -97,7 +98,9 @@ export class KompendiumComponent {
     public render(): HTMLElement {
         const tag = this.match.params.name;
         const component = findComponent(tag, this.docs);
-        const examples = findExamples(component, this.docs).filter(Boolean);
+        const examples = findExamples(component, this.docs).filter(
+            (example): example is JsonDocsComponent => Boolean(example),
+        );
 
         return (
             <article class="component">
@@ -244,7 +247,7 @@ function buildTocEntries(
             collapsibleSection(
                 SECTION_SLUGS.slots,
                 'Slots',
-                component.slots.map((slot) => slot.name),
+                component.slots.map((slot) => slotDisplayName(slot.name)),
             ),
         );
     }

--- a/src/components/component/slots.ts
+++ b/src/components/component/slots.ts
@@ -1,0 +1,10 @@
+/**
+ * Stencil reports a component's unnamed (default) slot with an empty
+ * string name. Normalize to a user-facing label so it renders and
+ * slugifies consistently across the docs page and the TOC.
+ * @param {string} name the raw slot name from JsonDocs
+ * @returns {string} the display name to use for headings and TOC entries
+ */
+export function slotDisplayName(name: string): string {
+    return name || 'default';
+}

--- a/src/components/component/templates/events.tsx
+++ b/src/components/component/templates/events.tsx
@@ -1,12 +1,15 @@
 import { JsonDocsEvent } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { ProplistItem } from '../../proplist/proplist';
+import { entrySlug } from '../anchors';
 
 export function EventList({
     events,
     id,
+    slugId,
 }: {
     id: string;
+    slugId: string;
     events: JsonDocsEvent[];
 }): HTMLElement[] {
     if (!events.length) {
@@ -14,14 +17,16 @@ export function EventList({
     }
 
     return [
+        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
         <h3 class="docs-layout-section-heading" id={id}>
             Events
+            <kompendium-anchor slug={slugId} label="Events" />
         </h3>,
-        ...events.map(renderEvent),
+        ...events.map(renderEvent(slugId)),
     ];
 }
 
-function renderEvent(event: JsonDocsEvent) {
+const renderEvent = (sectionSlug: string) => (event: JsonDocsEvent) => {
     const items: ProplistItem[] = [
         {
             key: 'Detail',
@@ -41,9 +46,16 @@ function renderEvent(event: JsonDocsEvent) {
         },
     ];
 
+    const slug = sectionSlug ? entrySlug(sectionSlug, event.event) : null;
+
     return (
         <div class="props-events-layout">
-            <h4>{event.event}</h4>
+            <h4 id={slug}>
+                {event.event}
+                {slug ? (
+                    <kompendium-anchor slug={slug} label={event.event} />
+                ) : null}
+            </h4>
             <kompendium-taglist tags={event.docsTags} />
             <div class="markdown-props">
                 <kompendium-markdown text={event.docs} />
@@ -51,4 +63,4 @@ function renderEvent(event: JsonDocsEvent) {
             </div>
         </div>
     );
-}
+};

--- a/src/components/component/templates/examples.tsx
+++ b/src/components/component/templates/examples.tsx
@@ -1,14 +1,17 @@
 import { JsonDocsComponent, JsonDocsTag } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { PropsFactory } from '../../playground/playground.types';
+import { exampleAnchorId } from '../anchors';
 
 export function ExampleList({
     examples,
     id,
+    slugId,
     schema,
     propsFactory,
 }: {
     id: string;
+    slugId: string;
     examples: JsonDocsComponent[];
     schema: Record<string, any>;
     propsFactory?: PropsFactory;
@@ -18,8 +21,10 @@ export function ExampleList({
     }
 
     return [
+        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
         <h3 class="docs-layout-section-heading" id={id}>
             Examples
+            <kompendium-anchor slug={slugId} label="Examples" />
         </h3>,
         examples.map(renderExample(schema, propsFactory)),
     ];
@@ -28,12 +33,17 @@ export function ExampleList({
 const renderExample =
     (schema: Record<string, any>, factory: PropsFactory) =>
     (example: JsonDocsComponent) => {
+        const slug = exampleAnchorId(example.docs, example.tag);
+
         return (
-            <kompendium-playground
-                component={example}
-                schema={schema}
-                propsFactory={factory}
-            />
+            <div class="example-wrapper" id={slug}>
+                <kompendium-playground
+                    anchorSlug={slug}
+                    component={example}
+                    schema={schema}
+                    propsFactory={factory}
+                />
+            </div>
         );
     };
 

--- a/src/components/component/templates/examples.tsx
+++ b/src/components/component/templates/examples.tsx
@@ -1,7 +1,7 @@
 import { JsonDocsComponent, JsonDocsTag } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { PropsFactory } from '../../playground/playground.types';
-import { exampleAnchorId } from '../anchors';
+import { uniqueExampleSlugs } from '../anchors';
 
 export function ExampleList({
     examples,
@@ -20,20 +20,22 @@ export function ExampleList({
         return;
     }
 
+    const slugs = uniqueExampleSlugs(examples);
+
     return [
         <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
         <h3 class="docs-layout-section-heading" id={id}>
             Examples
             <kompendium-anchor slug={slugId} label="Examples" />
         </h3>,
-        examples.map(renderExample(schema, propsFactory)),
+        examples.map(renderExample(slugs, schema, propsFactory)),
     ];
 }
 
 const renderExample =
-    (schema: Record<string, any>, factory: PropsFactory) =>
-    (example: JsonDocsComponent) => {
-        const slug = exampleAnchorId(example.docs, example.tag);
+    (slugs: string[], schema: Record<string, any>, factory: PropsFactory) =>
+    (example: JsonDocsComponent, index: number) => {
+        const slug = slugs[index];
 
         return (
             <div class="example-wrapper" id={slug}>

--- a/src/components/component/templates/methods.tsx
+++ b/src/components/component/templates/methods.tsx
@@ -6,12 +6,15 @@ import {
 import { h } from '@stencil/core';
 import { ProplistItem } from '../../proplist/proplist';
 import { ParameterDescription } from '../../../types';
+import { entrySlug } from '../anchors';
 
 export function MethodList({
     methods,
     id,
+    slugId,
 }: {
     id?: string;
+    slugId?: string;
     methods: Array<Partial<JsonDocsMethod>>;
 }): HTMLElement[] {
     if (!methods.length) {
@@ -19,24 +22,32 @@ export function MethodList({
     }
 
     return [
+        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
         <h3 class="docs-layout-section-heading" id={id}>
             Methods
+            <kompendium-anchor slug={slugId} label="Methods" />
         </h3>,
-        ...methods.map(renderMethod),
+        ...methods.map(renderMethod(slugId)),
     ];
 }
 
-function renderMethod(method: JsonDocsMethod) {
+const renderMethod = (sectionSlug: string) => (method: JsonDocsMethod) => {
     const items: ProplistItem[] = [
         {
             key: 'Signature',
             value: method.signature,
         },
     ].filter((item) => item.value !== undefined);
+    const slug = sectionSlug ? entrySlug(sectionSlug, method.name) : null;
 
     return (
         <div class="methods-layout">
-            <h4 class="methods-title">{method.name}</h4>
+            <h4 class="methods-title" id={slug}>
+                {method.name}
+                {slug ? (
+                    <kompendium-anchor slug={slug} label={method.name} />
+                ) : null}
+            </h4>
             <div class="methods-content">
                 <div>
                     <kompendium-markdown text={method.docs} />
@@ -52,7 +63,7 @@ function renderMethod(method: JsonDocsMethod) {
             </div>
         </div>
     );
-}
+};
 
 function ParamList({ params }: { params: JsonDocMethodParameter[] }) {
     if (!params.length) {

--- a/src/components/component/templates/methods.tsx
+++ b/src/components/component/templates/methods.tsx
@@ -22,10 +22,14 @@ export function MethodList({
     }
 
     return [
-        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h3 class="docs-layout-section-heading" id={id}>
             Methods
-            <kompendium-anchor slug={slugId} label="Methods" />
+            {slugId ? (
+                <kompendium-anchor slug={slugId} label="Methods" />
+            ) : null}
         </h3>,
         ...methods.map(renderMethod(slugId)),
     ];

--- a/src/components/component/templates/props.tsx
+++ b/src/components/component/templates/props.tsx
@@ -17,10 +17,14 @@ export function PropertyList({
     }
 
     return [
-        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h3 class="docs-layout-section-heading" id={id}>
             Properties
-            <kompendium-anchor slug={slugId} label="Properties" />
+            {slugId ? (
+                <kompendium-anchor slug={slugId} label="Properties" />
+            ) : null}
         </h3>,
         ...props.map(renderProperty(slugId)),
     ];

--- a/src/components/component/templates/props.tsx
+++ b/src/components/component/templates/props.tsx
@@ -1,12 +1,15 @@
 import { JsonDocsProp } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { ProplistItem } from '../../proplist/proplist';
+import { entrySlug } from '../anchors';
 
 export function PropertyList({
     props,
     id,
+    slugId,
 }: {
     id?: string;
+    slugId?: string;
     props: Array<Partial<JsonDocsProp>>;
 }): HTMLElement[] {
     if (!props.length) {
@@ -14,14 +17,16 @@ export function PropertyList({
     }
 
     return [
+        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
         <h3 class="docs-layout-section-heading" id={id}>
             Properties
+            <kompendium-anchor slug={slugId} label="Properties" />
         </h3>,
-        ...props.map(renderProperty),
+        ...props.map(renderProperty(slugId)),
     ];
 }
 
-function renderProperty(property: JsonDocsProp) {
+const renderProperty = (sectionSlug: string) => (property: JsonDocsProp) => {
     const items: ProplistItem[] = [
         {
             key: 'Type',
@@ -45,9 +50,16 @@ function renderProperty(property: JsonDocsProp) {
         },
     ].filter((item) => item.value !== undefined && item.value !== 'undefined');
 
+    const slug = sectionSlug ? entrySlug(sectionSlug, property.name) : null;
+
     return (
         <div class="props-events-layout">
-            <h4>{property.name}</h4>
+            <h4 id={slug}>
+                {property.name}
+                {slug ? (
+                    <kompendium-anchor slug={slug} label={property.name} />
+                ) : null}
+            </h4>
             <kompendium-taglist tags={property.docsTags} />
             <div class="markdown-props">
                 <kompendium-markdown text={property.docs} />
@@ -55,4 +67,4 @@ function renderProperty(property: JsonDocsProp) {
             </div>
         </div>
     );
-}
+};

--- a/src/components/component/templates/slots.tsx
+++ b/src/components/component/templates/slots.tsx
@@ -1,6 +1,7 @@
 import { JsonDocsSlot } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { entrySlug } from '../anchors';
+import { slotDisplayName } from '../slots';
 
 export function SlotList({
     slots,
@@ -26,15 +27,14 @@ export function SlotList({
 }
 
 const renderSlot = (sectionSlug: string) => (slot: JsonDocsSlot) => {
-    const slug = sectionSlug ? entrySlug(sectionSlug, slot.name) : null;
+    const name = slotDisplayName(slot.name);
+    const slug = sectionSlug ? entrySlug(sectionSlug, name) : null;
 
     return (
         <div>
             <h4 id={slug}>
-                {slot.name}
-                {slug ? (
-                    <kompendium-anchor slug={slug} label={slot.name} />
-                ) : null}
+                {name}
+                {slug ? <kompendium-anchor slug={slug} label={name} /> : null}
             </h4>
             <kompendium-markdown text={slot.docs} />
         </div>

--- a/src/components/component/templates/slots.tsx
+++ b/src/components/component/templates/slots.tsx
@@ -1,11 +1,14 @@
 import { JsonDocsSlot } from '@stencil/core/internal';
 import { h } from '@stencil/core';
+import { entrySlug } from '../anchors';
 
 export function SlotList({
     slots,
     id,
+    slugId,
 }: {
     id: string;
+    slugId: string;
     slots: JsonDocsSlot[];
 }): HTMLElement[] {
     if (!slots.length) {
@@ -13,18 +16,27 @@ export function SlotList({
     }
 
     return [
+        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
         <h3 class="docs-layout-section-heading" id={id}>
             Slots
+            <kompendium-anchor slug={slugId} label="Slots" />
         </h3>,
-        ...slots.map(renderSlot),
+        ...slots.map(renderSlot(slugId)),
     ];
 }
 
-function renderSlot(slot: JsonDocsSlot) {
+const renderSlot = (sectionSlug: string) => (slot: JsonDocsSlot) => {
+    const slug = sectionSlug ? entrySlug(sectionSlug, slot.name) : null;
+
     return (
         <div>
-            <h4>{slot.name}</h4>
+            <h4 id={slug}>
+                {slot.name}
+                {slug ? (
+                    <kompendium-anchor slug={slug} label={slot.name} />
+                ) : null}
+            </h4>
             <kompendium-markdown text={slot.docs} />
         </div>
     );
-}
+};

--- a/src/components/component/templates/style.tsx
+++ b/src/components/component/templates/style.tsx
@@ -1,11 +1,14 @@
 import { JsonDocsStyle } from '@stencil/core/internal';
 import { h } from '@stencil/core';
+import { entrySlug } from '../anchors';
 
 export function StyleList({
     styles,
     id,
+    slugId,
 }: {
     id: string;
+    slugId: string;
     styles: JsonDocsStyle[];
 }): HTMLElement[] {
     if (!styles.length) {
@@ -13,22 +16,29 @@ export function StyleList({
     }
 
     return [
+        <span class="section-anchor" id={slugId} aria-hidden="true"></span>,
         <h3 class="docs-layout-section-heading" id={id}>
             Styles
+            <kompendium-anchor slug={slugId} label="Styles" />
         </h3>,
-        ...styles.map(renderStyle),
+        ...styles.map(renderStyle(slugId)),
     ];
 }
 
-function renderStyle(style: JsonDocsStyle) {
+const renderStyle = (sectionSlug: string) => (style: JsonDocsStyle) => {
+    const slug = sectionSlug ? entrySlug(sectionSlug, style.name) : null;
+
     return (
         <div class="styles-layout">
-            <div class="styles-title">
+            <div class="styles-title" id={slug}>
                 <code>{style.name}</code>
+                {slug ? (
+                    <kompendium-anchor slug={slug} label={style.name} />
+                ) : null}
             </div>
             <div class="styles-content">
                 <kompendium-markdown text={style.docs} />
             </div>
         </div>
     );
-}
+};

--- a/src/components/playground/playground.scss
+++ b/src/components/playground/playground.scss
@@ -187,6 +187,17 @@ section.example {
     padding: functions.pxToRem(12);
 }
 
+.example-heading {
+    margin: 0 0 functions.pxToRem(12) 0;
+    font-size: functions.pxToRem(18);
+    line-height: functions.pxToRem(18);
+    font-weight: 500;
+
+    &:hover {
+        --kompendium-anchor-opacity: 1;
+    }
+}
+
 .show-case_component {
     font-family: var(--kompendium-example-font-family, inherit);
     font-size: var(--kompendium-example-font-size, inherit);

--- a/src/components/playground/playground.tsx
+++ b/src/components/playground/playground.tsx
@@ -105,16 +105,17 @@ export class Playground {
             ...factory(ExampleComponent),
         };
         const { title, body } = splitDocs(this.component.docs);
+        const heading = title || this.component.tag;
 
         return (
             <div class="show-case">
                 <div class="show-case_description">
                     <h5 class="example-heading">
-                        {title}
+                        {heading}
                         {this.anchorSlug ? (
                             <kompendium-anchor
                                 slug={this.anchorSlug}
-                                label={title}
+                                label={heading}
                             />
                         ) : null}
                     </h5>
@@ -201,14 +202,17 @@ export class Playground {
 }
 
 function splitDocs(docs: string): { title: string; body: string } {
-    const text = docs || '';
-    const newlineIndex = text.indexOf('\n');
-    if (newlineIndex === -1) {
-        return { title: text.trim(), body: '' };
+    const lines = (docs || '').split('\n');
+    const titleIndex = lines.findIndex((line) => line.trim().length > 0);
+    if (titleIndex === -1) {
+        return { title: '', body: '' };
     }
 
     return {
-        title: text.substring(0, newlineIndex).trim(),
-        body: text.substring(newlineIndex + 1).trim(),
+        title: lines[titleIndex].trim(),
+        body: lines
+            .slice(titleIndex + 1)
+            .join('\n')
+            .trim(),
     };
 }

--- a/src/components/playground/playground.tsx
+++ b/src/components/playground/playground.tsx
@@ -29,6 +29,12 @@ export class Playground {
     @Prop()
     public propsFactory?: PropsFactory = () => ({});
 
+    /**
+     * Slug used as the URL anchor for linking to this example.
+     */
+    @Prop()
+    public anchorSlug?: string;
+
     @State()
     private activeTab: string;
 
@@ -93,17 +99,26 @@ export class Playground {
 
     private renderResult() {
         const ExampleComponent = this.component.tag;
-        const text = '##### ' + this.component.docs;
         const factory = this.propsFactory;
         const props = {
             schema: this.schema,
             ...factory(ExampleComponent),
         };
+        const { title, body } = splitDocs(this.component.docs);
 
         return (
             <div class="show-case">
                 <div class="show-case_description">
-                    <kompendium-markdown text={text} />
+                    <h5 class="example-heading">
+                        {title}
+                        {this.anchorSlug ? (
+                            <kompendium-anchor
+                                slug={this.anchorSlug}
+                                label={title}
+                            />
+                        ) : null}
+                    </h5>
+                    {body ? <kompendium-markdown text={body} /> : null}
                 </div>
                 <div class="show-case_component">
                     {this.renderDebugButton(this.component.tag)}
@@ -182,5 +197,18 @@ export class Playground {
 
     private themeListener = (event: CustomEvent<Theme>) => {
         this.theme = event.detail;
+    };
+}
+
+function splitDocs(docs: string): { title: string; body: string } {
+    const text = docs || '';
+    const newlineIndex = text.indexOf('\n');
+    if (newlineIndex === -1) {
+        return { title: text.trim(), body: '' };
+    }
+
+    return {
+        title: text.substring(0, newlineIndex).trim(),
+        body: text.substring(newlineIndex + 1).trim(),
     };
 }

--- a/src/components/toc/toc.scss
+++ b/src/components/toc/toc.scss
@@ -1,0 +1,185 @@
+@use '../../style/functions.scss';
+@use '../../style/variables.scss';
+@use '../../style/mixins.scss';
+
+:host {
+    display: contents;
+    font-family: var(--kompendium-font-primary);
+}
+
+.toc.hidden {
+    display: none;
+}
+
+.fab {
+    position: fixed;
+    top: functions.pxToRem(24);
+    right: functions.pxToRem(24);
+    z-index: 110;
+
+    width: functions.pxToRem(48);
+    height: functions.pxToRem(48);
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+
+    background-color: rgb(var(--kompendium-contrast-200));
+    color: rgb(var(--kompendium-contrast-1100));
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @include mixins.is-elevated-clickable;
+}
+
+.scrim {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background-color: rgba(var(--kompendium-color-black), 0.24);
+    backdrop-filter: blur(functions.pxToRem(2));
+}
+
+.panel {
+    display: none;
+    position: fixed;
+    z-index: 105;
+    right: functions.pxToRem(24);
+    top: functions.pxToRem(84);
+
+    width: min(
+        #{functions.pxToRem(360)},
+        calc(100vw - #{functions.pxToRem(48)})
+    );
+    max-height: calc(100vh - #{functions.pxToRem(120)});
+    overflow-y: auto;
+
+    background-color: rgb(var(--kompendium-contrast-200));
+    color: rgb(var(--kompendium-contrast-1100));
+
+    border-radius: functions.pxToRem(12);
+    box-shadow: var(--kompendium-shadow-depth-16);
+    padding: functions.pxToRem(16) functions.pxToRem(20);
+}
+
+.heading {
+    margin: 0 0 functions.pxToRem(8) 0;
+    font-size: functions.pxToRem(13);
+    font-variant: all-small-caps;
+    letter-spacing: functions.pxToRem(1);
+    color: rgb(var(--kompendium-contrast-900));
+    font-weight: 500;
+}
+
+.entries {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.entry {
+    margin: 0;
+    padding: 0;
+
+    &::before {
+        display: none;
+        content: none;
+    }
+}
+
+.entry-row {
+    display: flex;
+    align-items: center;
+    gap: functions.pxToRem(2);
+}
+
+.toggle {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    width: functions.pxToRem(20);
+    height: functions.pxToRem(20);
+    padding: 0;
+
+    background: transparent;
+    border: none;
+    border-radius: functions.pxToRem(4);
+    cursor: pointer;
+
+    color: rgb(var(--kompendium-contrast-900));
+
+    svg {
+        transition: transform 0.15s ease;
+    }
+
+    &.expanded svg {
+        transform: rotate(90deg);
+    }
+
+    &:hover {
+        background-color: rgba(var(--kompendium-contrast-400), 0.8);
+        color: rgb(var(--kompendium-contrast-1100));
+    }
+
+    @include mixins.visualize-keyboard-focus();
+}
+
+.link {
+    flex: 1;
+    display: block;
+    padding: functions.pxToRem(6) functions.pxToRem(8);
+    border-radius: functions.pxToRem(4);
+    color: rgb(var(--kompendium-contrast-1100));
+    text-decoration: none;
+    font-size: functions.pxToRem(14);
+    line-height: functions.pxToRem(20);
+
+    &:hover {
+        background-color: rgba(var(--kompendium-contrast-400), 0.8);
+        color: rgb(var(--kompendium-color-blue-default));
+    }
+
+    @include mixins.visualize-keyboard-focus();
+}
+
+.children {
+    list-style: none;
+    margin: functions.pxToRem(2) 0 functions.pxToRem(4) functions.pxToRem(12);
+    padding: 0 0 0 functions.pxToRem(12);
+    border-left: 1px solid rgb(var(--kompendium-contrast-500));
+
+    .entry::before {
+        display: none;
+        content: none;
+    }
+
+    .link {
+        font-size: functions.pxToRem(13);
+        color: rgb(var(--kompendium-contrast-1000));
+    }
+}
+
+.toc.open {
+    .scrim,
+    .panel {
+        display: block;
+    }
+}
+
+@media (max-width: variables.$break-point-small) {
+    .panel {
+        right: functions.pxToRem(16);
+        left: functions.pxToRem(16);
+        max-width: none;
+    }
+
+    .fab {
+        top: functions.pxToRem(16);
+        right: functions.pxToRem(16);
+    }
+}

--- a/src/components/toc/toc.tsx
+++ b/src/components/toc/toc.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, State, Watch } from '@stencil/core';
+import { Component, Element, h, Prop, State, Watch } from '@stencil/core';
 import { TocEntry } from './toc.types';
 import { anchorHref } from '../component/anchors';
 import { getAnchorId } from '../anchor-scroll';
@@ -28,6 +28,9 @@ export class Toc {
     @State()
     private userToggles = new Map<string, boolean>();
 
+    @Element()
+    private host: HTMLKompendiumTocElement;
+
     constructor() {
         this.handleKeydown = this.handleKeydown.bind(this);
         this.handleHashChange = this.handleHashChange.bind(this);
@@ -45,8 +48,41 @@ export class Toc {
     }
 
     @Watch('entries')
-    protected onEntriesChange(): void {
+    protected onEntriesChange(newEntries: TocEntry[]): void {
+        const validIds = collectIds(newEntries || []);
+        const pruned = new Map<string, boolean>();
+        for (const [id, value] of this.userToggles) {
+            if (validIds.has(id)) {
+                pruned.set(id, value);
+            }
+        }
+
+        this.userToggles = pruned;
         this.expandSectionForActiveAnchor();
+    }
+
+    @Watch('open')
+    protected onOpenChange(isOpen: boolean, wasOpen: boolean): void {
+        if (isOpen === wasOpen) {
+            return;
+        }
+
+        const shadow = this.host.shadowRoot;
+        if (!shadow) {
+            return;
+        }
+
+        if (isOpen) {
+            requestAnimationFrame(() => {
+                const first = shadow.querySelector<HTMLElement>(
+                    '.panel a, .panel button',
+                );
+                first?.focus();
+            });
+        } else {
+            const fab = shadow.querySelector<HTMLElement>('.fab');
+            fab?.focus();
+        }
     }
 
     public render(): HTMLElement {
@@ -64,6 +100,7 @@ export class Toc {
                 <div
                     class="panel"
                     role="dialog"
+                    aria-modal="true"
                     aria-label="Table of contents"
                     onClick={stopPropagation}
                 >
@@ -108,7 +145,7 @@ export class Toc {
                     <a
                         class="link"
                         href={anchorHref(entry.id)}
-                        onClick={this.close}
+                        onClick={this.handleLinkClick}
                     >
                         {entry.title}
                     </a>
@@ -126,6 +163,20 @@ export class Toc {
 
     private close = (): void => {
         this.open = false;
+    };
+
+    private handleLinkClick = (event: MouseEvent): void => {
+        if (
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.altKey ||
+            event.button !== 0
+        ) {
+            return;
+        }
+
+        this.close();
     };
 
     private toggleExpanded =
@@ -178,6 +229,18 @@ export class Toc {
         next.set(parent.id, true);
         this.userToggles = next;
     }
+}
+
+function collectIds(
+    entries: TocEntry[],
+    acc: Set<string> = new Set(),
+): Set<string> {
+    for (const entry of entries) {
+        acc.add(entry.id);
+        collectIds(entry.children || [], acc);
+    }
+
+    return acc;
 }
 
 function findEntryById(id: string, entries: TocEntry[]): TocEntry | null {

--- a/src/components/toc/toc.tsx
+++ b/src/components/toc/toc.tsx
@@ -74,9 +74,11 @@ export class Toc {
 
         if (isOpen) {
             requestAnimationFrame(() => {
-                const first = shadow.querySelector<HTMLElement>(
-                    '.panel a, .panel button',
-                );
+                const first =
+                    shadow.querySelector<HTMLElement>('.panel .link') ||
+                    shadow.querySelector<HTMLElement>(
+                        '.panel a, .panel button',
+                    );
                 first?.focus();
             });
         } else {

--- a/src/components/toc/toc.tsx
+++ b/src/components/toc/toc.tsx
@@ -218,18 +218,25 @@ export class Toc {
             return;
         }
 
-        const parent = findParentOf(activeId, this.entries);
-        if (!parent || !parent.collapsible) {
-            return;
-        }
-
-        if (this.isEntryExpanded(parent)) {
+        const ancestors = findAncestorsOf(activeId, this.entries).filter(
+            (entry) => entry.collapsible,
+        );
+        if (!ancestors.length) {
             return;
         }
 
         const next = new Map(this.userToggles);
-        next.set(parent.id, true);
-        this.userToggles = next;
+        let changed = false;
+        for (const ancestor of ancestors) {
+            if (!this.isEntryExpanded(ancestor)) {
+                next.set(ancestor.id, true);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            this.userToggles = next;
+        }
     }
 }
 
@@ -260,20 +267,24 @@ function findEntryById(id: string, entries: TocEntry[]): TocEntry | null {
     return null;
 }
 
-function findParentOf(targetId: string, entries: TocEntry[]): TocEntry | null {
+function findAncestorsOf(
+    targetId: string,
+    entries: TocEntry[],
+    trail: TocEntry[] = [],
+): TocEntry[] {
     for (const entry of entries) {
         const children = entry.children || [];
         if (children.some((child) => child.id === targetId)) {
-            return entry;
+            return [...trail, entry];
         }
 
-        const deeper = findParentOf(targetId, children);
-        if (deeper) {
+        const deeper = findAncestorsOf(targetId, children, [...trail, entry]);
+        if (deeper.length) {
             return deeper;
         }
     }
 
-    return null;
+    return [];
 }
 
 const stopPropagation = (event: MouseEvent): void => {

--- a/src/components/toc/toc.tsx
+++ b/src/components/toc/toc.tsx
@@ -1,0 +1,261 @@
+import { Component, h, Prop, State, Watch } from '@stencil/core';
+import { TocEntry } from './toc.types';
+import { anchorHref } from '../component/anchors';
+import { getAnchorId } from '../anchor-scroll';
+
+/**
+ * Floating table-of-contents menu. Clicking the button reveals an overlay
+ * listing the entries. Selecting an entry updates the URL hash with a slug
+ * anchor (e.g. `#/component/my-component#basic-example`) so the page can
+ * scroll to the target and the location can be shared.
+ * @private
+ */
+@Component({
+    tag: 'kompendium-toc',
+    styleUrl: 'toc.scss',
+    shadow: true,
+})
+export class Toc {
+    /**
+     * Entries to show in the menu. A flat or nested list of links.
+     */
+    @Prop()
+    public entries: TocEntry[] = [];
+
+    @State()
+    private open = false;
+
+    @State()
+    private userToggles = new Map<string, boolean>();
+
+    constructor() {
+        this.handleKeydown = this.handleKeydown.bind(this);
+        this.handleHashChange = this.handleHashChange.bind(this);
+    }
+
+    public connectedCallback(): void {
+        document.addEventListener('keydown', this.handleKeydown);
+        window.addEventListener('hashchange', this.handleHashChange);
+        this.expandSectionForActiveAnchor();
+    }
+
+    public disconnectedCallback(): void {
+        document.removeEventListener('keydown', this.handleKeydown);
+        window.removeEventListener('hashchange', this.handleHashChange);
+    }
+
+    @Watch('entries')
+    protected onEntriesChange(): void {
+        this.expandSectionForActiveAnchor();
+    }
+
+    public render(): HTMLElement {
+        if (!this.entries || !this.entries.length) {
+            return <div class="toc hidden"></div>;
+        }
+
+        return (
+            <div class={{ toc: true, open: this.open }}>
+                <div
+                    class="scrim"
+                    onClick={this.close}
+                    aria-hidden="true"
+                ></div>
+                <div
+                    class="panel"
+                    role="dialog"
+                    aria-label="Table of contents"
+                    onClick={stopPropagation}
+                >
+                    <h2 class="heading">On this page</h2>
+                    <ul class="entries">
+                        {this.entries.map(this.renderEntry)}
+                    </ul>
+                </div>
+                <button
+                    type="button"
+                    class="fab"
+                    onClick={this.toggle}
+                    aria-label="Table of contents"
+                    aria-expanded={this.open ? 'true' : 'false'}
+                >
+                    {this.open ? renderCloseIcon() : renderMenuIcon()}
+                </button>
+            </div>
+        );
+    }
+
+    private renderEntry = (entry: TocEntry): HTMLElement => {
+        const children = entry.children || [];
+        const hasChildren = children.length > 0;
+        const collapsible = !!entry.collapsible && hasChildren;
+        const expanded = collapsible ? this.isEntryExpanded(entry) : true;
+
+        return (
+            <li class={{ entry: true, collapsible: collapsible }}>
+                <div class="entry-row">
+                    {collapsible ? (
+                        <button
+                            type="button"
+                            class={{ toggle: true, expanded: expanded }}
+                            onClick={this.toggleExpanded(entry.id)}
+                            aria-expanded={expanded ? 'true' : 'false'}
+                            aria-label={`Toggle ${entry.title}`}
+                        >
+                            {renderChevron()}
+                        </button>
+                    ) : null}
+                    <a
+                        class="link"
+                        href={anchorHref(entry.id)}
+                        onClick={this.close}
+                    >
+                        {entry.title}
+                    </a>
+                </div>
+                {hasChildren && expanded ? (
+                    <ul class="children">{children.map(this.renderEntry)}</ul>
+                ) : null}
+            </li>
+        );
+    };
+
+    private toggle = (): void => {
+        this.open = !this.open;
+    };
+
+    private close = (): void => {
+        this.open = false;
+    };
+
+    private toggleExpanded =
+        (id: string) =>
+        (event: MouseEvent): void => {
+            event.preventDefault();
+            event.stopPropagation();
+            const entry = findEntryById(id, this.entries);
+            const current = entry ? this.isEntryExpanded(entry) : false;
+            const next = new Map(this.userToggles);
+            next.set(id, !current);
+            this.userToggles = next;
+        };
+
+    private isEntryExpanded(entry: TocEntry): boolean {
+        const explicit = this.userToggles.get(entry.id);
+        if (explicit !== undefined) {
+            return explicit;
+        }
+
+        return !!entry.defaultExpanded;
+    }
+
+    private handleKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Escape' && this.open) {
+            this.open = false;
+        }
+    }
+
+    private handleHashChange(): void {
+        this.expandSectionForActiveAnchor();
+    }
+
+    private expandSectionForActiveAnchor(): void {
+        const activeId = getAnchorId();
+        if (!activeId) {
+            return;
+        }
+
+        const parent = findParentOf(activeId, this.entries);
+        if (!parent || !parent.collapsible) {
+            return;
+        }
+
+        if (this.isEntryExpanded(parent)) {
+            return;
+        }
+
+        const next = new Map(this.userToggles);
+        next.set(parent.id, true);
+        this.userToggles = next;
+    }
+}
+
+function findEntryById(id: string, entries: TocEntry[]): TocEntry | null {
+    for (const entry of entries) {
+        if (entry.id === id) {
+            return entry;
+        }
+
+        const deeper = findEntryById(id, entry.children || []);
+        if (deeper) {
+            return deeper;
+        }
+    }
+
+    return null;
+}
+
+function findParentOf(targetId: string, entries: TocEntry[]): TocEntry | null {
+    for (const entry of entries) {
+        const children = entry.children || [];
+        if (children.some((child) => child.id === targetId)) {
+            return entry;
+        }
+
+        const deeper = findParentOf(targetId, children);
+        if (deeper) {
+            return deeper;
+        }
+    }
+
+    return null;
+}
+
+const stopPropagation = (event: MouseEvent): void => {
+    event.stopPropagation();
+};
+
+const renderMenuIcon = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="24"
+        height="24"
+        aria-hidden="true"
+    >
+        <path
+            fill="currentColor"
+            d="M3 4h18v2H3V4zm0 7h12v2H3v-2zm0 7h18v2H3v-2z"
+        />
+    </svg>
+);
+
+const renderCloseIcon = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="24"
+        height="24"
+        aria-hidden="true"
+    >
+        <path
+            fill="currentColor"
+            d="M18.3 5.71 12 12l6.3 6.29-1.41 1.42L10.58 13.4l-6.29 6.3-1.42-1.41L9.17 12 2.87 5.71 4.29 4.3l6.29 6.3 6.3-6.3z"
+        />
+    </svg>
+);
+
+const renderChevron = () => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="16"
+        height="16"
+        aria-hidden="true"
+    >
+        <path
+            fill="currentColor"
+            d="M8.59 16.34 13.17 11.75 8.59 7.17 10 5.75l6 6-6 6z"
+        />
+    </svg>
+);

--- a/src/components/toc/toc.types.ts
+++ b/src/components/toc/toc.types.ts
@@ -1,0 +1,17 @@
+export interface TocEntry {
+    id: string;
+    title: string;
+    children?: TocEntry[];
+
+    /**
+     * When true, the entry's children are hidden behind an expand/collapse
+     * toggle in the table of contents. Defaults to false.
+     */
+    collapsible?: boolean;
+
+    /**
+     * When true, a collapsible entry starts expanded. The user can still
+     * collapse it manually. Ignored when `collapsible` is false.
+     */
+    defaultExpanded?: boolean;
+}


### PR DESCRIPTION
## Summary
- Adds a floating **table of contents** on each component docs page (top-right FAB that opens an overlay), covering Examples and all subsections (Properties / Events / Methods / Slots / Styles) with collapsible groups.
- Adds a ¶ **anchor link** next to every heading — section headings, the example titles inside each playground, and every per-entry heading under Properties/Events/Methods/Slots/Styles. The anchor becomes visible on heading hover and highlights blue when the current URL matches its slug.
- Clicking an active anchor removes the fragment from the URL (via `history.replaceState`) without scrolling.
- Closes #165.

## Details
- New `kompendium-anchor` component + URL helpers in `src/components/component/anchors.ts`.
- New `kompendium-toc` component with explicit user-toggle state, `defaultExpanded` support, and auto-expand when the URL matches a child.
- Playground now renders the example title (first docs line) in-place as an `h5` so the anchor can sit next to the text; the rest of the docs still flow through `kompendium-markdown`.
- Scroll fix in `kompendium-component`: the secondary-hash change now scrolls directly from the hashchange handler, since stencil-router's `match` doesn't re-render for fragment-only URL changes.
- Example slugs are derived from the title text (e.g. "With icons" → `#with-icons`) so the URL matches what the user sees.

## Test plan
- [ ] Visit a component page — confirm the TOC FAB appears top-right.
- [ ] Open the TOC — Examples should be expanded by default; Properties/Events/Methods/Slots/Styles should be collapsed and expandable via the chevron.
- [ ] Click a TOC entry — URL gains `#slug`, page scrolls to that heading, anchor icon turns blue.
- [ ] Hover any heading — ¶ icon fades in; hover away — fades out.
- [ ] Click the blue (active) ¶ icon — URL fragment clears, icon goes back to hover-only, **page does not scroll**.
- [ ] Open a URL like `#/component/<tag>#basic-example` directly — page scrolls to that example and its anchor highlights on load.
- [ ] Old-style URLs like `#/component/<tag>/examples/` still scroll to the Examples section (backward compatibility).

## Demo video of how it works in ***Lime elements***

### On desktop size

https://github.com/user-attachments/assets/41285945-757b-4a16-85c9-438417f296e9

### On mobile size

https://github.com/user-attachments/assets/410327f4-4978-401f-95a4-2dee2d76bcd4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an inline anchor link component and deterministic, shareable slugs across component docs (Examples, Properties, Events, Methods, Slots, Styles).
  * Introduced a floating, collapsible table of contents with keyboard accessibility, focus management, and automatic expansion to the active anchor.
  * Enhanced the playground to split docs into a title/body heading and support optional per-example anchor navigation.

* **Style**
  * Added/updated hover and focus styling to reveal anchor controls and improve visual affordances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->