### PR TITLE
fix: remove heading level skips from the heading outline

### DIFF
--- a/src/components/component-title.ts
+++ b/src/components/component-title.ts
@@ -1,0 +1,10 @@
+/**
+ * Get a human readable title for a component, e.g. `my-button` => `Button`
+ * @param {string} tag the tag name of the component
+ * @returns {string} the title of the component
+ */
+export function getComponentTitle(tag: string): string {
+    const title = tag.split('-').slice(1).join(' ');
+
+    return title[0].toLocaleUpperCase() + title.slice(1);
+}

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -14,6 +14,7 @@ import { ExampleList } from './templates/examples';
 import negate from 'lodash/negate';
 import { PropsFactory } from '../playground/playground.types';
 import { getRoute, scrollToElement } from '../anchor-scroll';
+import { getComponentTitle } from '../component-title';
 
 @Component({
     tag: 'kompendium-component',
@@ -93,8 +94,7 @@ export class KompendiumComponent {
     }
 
     private renderDocs(tag: string, component: JsonDocsComponent) {
-        let title = tag.split('-').slice(1).join(' ');
-        title = title[0].toLocaleUpperCase() + title.slice(1);
+        const title = getComponentTitle(tag);
         const examples = findExamples(component, this.docs);
         const tags = component.docsTags
             .filter(negate(isTag('slot')))

--- a/src/components/component/templates/examples.spec.tsx
+++ b/src/components/component/templates/examples.spec.tsx
@@ -1,0 +1,56 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { JsonDocsComponent } from '@stencil/core/internal';
+import { h } from '@stencil/core';
+import { ExampleList } from './examples';
+import { Playground } from '../../playground/playground';
+
+const example: JsonDocsComponent = {
+    tag: 'my-component-example',
+    docs: 'Basic example',
+    docsTags: [],
+} as any;
+
+describe('ExampleList', () => {
+    it('renders the section heading as an h2', async () => {
+        const page = await newSpecPage({
+            components: [Playground],
+            template: () => (
+                <div>
+                    <ExampleList
+                        examples={[example]}
+                        id="component/my-component/examples/"
+                        schema={undefined}
+                    />
+                </div>
+            ),
+        });
+
+        const heading = page.body.querySelector(
+            'h2.docs-layout-section-heading',
+        );
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toEqual('Examples');
+        expect(heading.id).toEqual('component/my-component/examples/');
+    });
+
+    it('does not render any heading below h2 for the section', async () => {
+        const page = await newSpecPage({
+            components: [Playground],
+            template: () => (
+                <div>
+                    <ExampleList
+                        examples={[example]}
+                        id="component/my-component/examples/"
+                        schema={undefined}
+                    />
+                </div>
+            ),
+        });
+
+        expect(
+            page.body.querySelector(
+                'h3.docs-layout-section-heading, h4.docs-layout-section-heading, h5.docs-layout-section-heading',
+            ),
+        ).toBeNull();
+    });
+});

--- a/src/components/component/templates/examples.tsx
+++ b/src/components/component/templates/examples.tsx
@@ -18,9 +18,9 @@ export function ExampleList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Examples
-        </h3>,
+        </h2>,
         examples.map(renderExample(schema, propsFactory)),
     ];
 }

--- a/src/components/debug/debug.scss
+++ b/src/components/debug/debug.scss
@@ -1,0 +1,21 @@
+@use '../../style/functions.scss';
+
+// The context headings exist to give the debug page the same heading
+// outline as the component page; visually they are deliberately small,
+// since the example component is the main content here.
+.context-heading {
+    margin: 0;
+    font-weight: 500;
+    color: rgb(var(--kompendium-contrast-900));
+}
+
+h2.context-heading {
+    font-size: functions.pxToRem(14);
+    line-height: functions.pxToRem(20);
+}
+
+h3.context-heading {
+    font-size: functions.pxToRem(12);
+    line-height: functions.pxToRem(16);
+    margin-bottom: functions.pxToRem(8);
+}

--- a/src/components/debug/debug.spec.tsx
+++ b/src/components/debug/debug.spec.tsx
@@ -1,0 +1,55 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { JsonDocs } from '@stencil/core/internal';
+import { h } from '@stencil/core';
+import { KompendiumDebug } from './debug';
+
+const docs: JsonDocs = {
+    components: [
+        {
+            tag: 'my-button',
+            docs: 'A button.',
+            docsTags: [
+                {
+                    name: 'exampleComponent',
+                    text: 'my-button-example',
+                },
+            ],
+        },
+        {
+            tag: 'my-button-example',
+            docs: 'Basic button\n\nA longer description.',
+            docsTags: [],
+        },
+    ],
+} as any;
+
+async function createPage() {
+    return newSpecPage({
+        components: [KompendiumDebug],
+        template: () => (
+            <kompendium-debug
+                docs={docs}
+                schemas={[{ $id: 'my-button' }]}
+                match={{ params: { name: 'my-button-example' } } as any}
+            />
+        ),
+    });
+}
+
+describe('kompendium-debug', () => {
+    it('renders the component name as an h2 heading', async () => {
+        const page = await createPage();
+
+        const heading = page.root.shadowRoot.querySelector('h2');
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toEqual('Button');
+    });
+
+    it('renders the example title as an h3 heading', async () => {
+        const page = await createPage();
+
+        const heading = page.root.shadowRoot.querySelector('h3');
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toEqual('Basic button');
+    });
+});

--- a/src/components/debug/debug.tsx
+++ b/src/components/debug/debug.tsx
@@ -6,9 +6,11 @@ import {
 } from '@stencil/core/internal';
 import { MatchResults } from '@limetech/stencil-router';
 import { PropsFactory } from '../playground/playground.types';
+import { getComponentTitle } from '../component-title';
 
 @Component({
     tag: 'kompendium-debug',
+    styleUrl: 'debug.scss',
     shadow: true,
 })
 export class KompendiumDebug {
@@ -60,13 +62,33 @@ export class KompendiumDebug {
             ...factory(ExampleComponent),
         };
 
-        return (
+        return [
+            this.renderHeadings(component, ownerComponent),
             <div class="show-case">
                 <div class="show-case_component">
                     <ExampleComponent {...props} />
                 </div>
-            </div>
-        );
+            </div>,
+        ];
+    }
+
+    /*
+     * Render the same heading context as the component page, so that the
+     * heading outline of an example is identical on both pages, e.g. when
+     * testing for accessibility
+     */
+    private renderHeadings(
+        component: JsonDocsComponent,
+        ownerComponent: JsonDocsComponent,
+    ) {
+        const exampleTitle = component.docs?.split('\n')[0];
+
+        return [
+            <h2 class="context-heading">
+                {getComponentTitle(ownerComponent.tag)}
+            </h2>,
+            !!exampleTitle && <h3 class="context-heading">{exampleTitle}</h3>,
+        ];
     }
 }
 

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -117,3 +117,15 @@ blockquote {
     color: rgb(var(--kompendium-contrast-1100));
     padding-left: 1rem;
 }
+
+h3 {
+    // The custom properties let the playground keep the example title at
+    // the size it had back when it was an h5; the fallbacks match the
+    // regular h3 styles in typography.scss.
+    font-size: var(--kompendium-markdown-h3-font-size, functions.pxToRem(22));
+    line-height: var(
+        --kompendium-markdown-h3-line-height,
+        functions.pxToRem(24)
+    );
+    margin-top: var(--kompendium-markdown-h3-margin-top, functions.pxToRem(16));
+}

--- a/src/components/playground/playground.scss
+++ b/src/components/playground/playground.scss
@@ -185,6 +185,12 @@ section.example {
 
 .show-case_description {
     padding: functions.pxToRem(12);
+
+    // The example title is an h3 element for the sake of the document
+    // outline, but keeps the size it had back when it was an h5.
+    --kompendium-markdown-h3-font-size: #{functions.pxToRem(18)};
+    --kompendium-markdown-h3-line-height: #{functions.pxToRem(18)};
+    --kompendium-markdown-h3-margin-top: #{functions.pxToRem(12)};
 }
 
 .show-case_component {

--- a/src/components/playground/playground.spec.tsx
+++ b/src/components/playground/playground.spec.tsx
@@ -1,0 +1,27 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { JsonDocsComponent } from '@stencil/core/internal';
+import { h } from '@stencil/core';
+import { Playground } from './playground';
+
+const example: JsonDocsComponent = {
+    tag: 'my-component-example',
+    docs: 'Basic example\n\nA longer description.',
+    docsTags: [],
+} as any;
+
+describe('kompendium-playground', () => {
+    it('renders the example title as an h3 heading', async () => {
+        const page = await newSpecPage({
+            components: [Playground],
+            template: () => (
+                <kompendium-playground component={example} schema={undefined} />
+            ),
+        });
+
+        const markdown = page.root.shadowRoot.querySelector(
+            'kompendium-markdown',
+        );
+        const text = (markdown as any).text ?? markdown.getAttribute('text');
+        expect(text).toEqual('### Basic example\n\nA longer description.');
+    });
+});

--- a/src/components/playground/playground.tsx
+++ b/src/components/playground/playground.tsx
@@ -93,7 +93,7 @@ export class Playground {
 
     private renderResult() {
         const ExampleComponent = this.component.tag;
-        const text = '##### ' + this.component.docs;
+        const text = '### ' + this.component.docs;
         const factory = this.propsFactory;
         const props = {
             schema: this.schema,

--- a/src/style/global-layout-rules.scss
+++ b/src/style/global-layout-rules.scss
@@ -11,6 +11,11 @@ kompendium-playground {
     margin: functions.pxToRem(40) 0 functions.pxToRem(20) 0;
     border-top: 1px solid rgb(var(--kompendium-contrast-500));
 
+    // The section headings are h2 elements for the sake of the document
+    // outline, but are sized like h3 headings by design.
+    font-size: functions.pxToRem(22);
+    line-height: functions.pxToRem(24);
+
     &:before {
         content: '';
         width: functions.pxToRem(2);


### PR DESCRIPTION
Fixes #184. Related: #31.

## What

The heading outline of a generated component page skipped levels (h1 → h3 "Examples" → h5 example titles), which violates axe's [heading-order](https://dequeuniversity.com/rules/axe/4.10/heading-order) rule and makes screen-reader navigation harder. The `#/debug/<tag>` route had the opposite problem: no heading context at all. Together this meant no example markup heading level could be correct on both pages (details in #184).

## How

The fix separates heading *level* (document structure) from *appearance* (font size) — the visual design is unchanged:

- **"Examples" section heading: h3 → h2**, still sized like an h3 via `.docs-layout-section-heading`. The other section headings (Properties, Events, …) are deliberately left as h3: they only ever follow h3-or-lower headings, so they don't skip, and raising them would *create* h2 → h4 skips against their h4 children.
- **Example titles: h5 → h3** (the `'##### '` prefix in the playground is now `'### '`, which is also what a comment in #31 suggested). They keep their old h5 size via CSS custom properties that the playground sets on `kompendium-markdown` (`--kompendium-markdown-h3-*`); the fallbacks match `typography.scss`, so markdown rendered anywhere else is unaffected.
- **The debug route renders the same heading context as the component page**: the component name as an h2 and the example title (first line of the example's docs) as an h3, both visually small since the example component is the main content on that page.

With this outline (h1 → h2 Examples → h3 example title), example markup using h4 captions is correct on both the component page and the debug page.

## Notes

- New spec tests cover all three changes (written first, watched fail).
- Verified visually against kompendium's own docs: component pages look identical to before; the debug page gains the two small context headings.
- Minor cosmetic limitation: the debug page's h3 renders the docs' first line as plain text, so inline markdown like backticks shows literally there (the playground still renders it as markdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug page now displays component and example titles with proper visual hierarchy.

* **Style**
  * Updated heading styles across components for improved visual hierarchy.
  * Example section headings now styled with enhanced formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->