### PR TITLE
feat(component): table of contents and anchor links on docs pages

### DIFF
--- a/src/components/anchor/anchor.scss
+++ b/src/components/anchor/anchor.scss
@@ -1,0 +1,30 @@
+:host {
+    display: inline;
+}
+
+.anchor {
+    display: inline;
+    margin-left: 0.25em;
+
+    color: rgb(var(--kompendium-contrast-700));
+    text-decoration: none;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+
+    opacity: var(--kompendium-anchor-opacity, 0);
+    transition:
+        opacity 0.2s ease,
+        color 0.2s ease;
+
+    &:hover,
+    &:focus-visible {
+        color: rgb(var(--kompendium-color-blue-default));
+        opacity: 1;
+    }
+
+    &.active {
+        color: rgb(var(--kompendium-color-blue-default));
+        opacity: 1;
+    }
+}

--- a/src/components/anchor/anchor.tsx
+++ b/src/components/anchor/anchor.tsx
@@ -1,0 +1,77 @@
+import { Component, h, Prop, State } from '@stencil/core';
+import { anchorHref, currentRoute } from '../component/anchors';
+import { getAnchorId } from '../anchor-scroll';
+
+/**
+ * Inline paragraph-link (¶) placed next to a heading. Picks up the parent
+ * heading's font-size, stays hidden until the heading is hovered, and
+ * highlights persistently when its slug matches the current URL anchor.
+ * @private
+ */
+@Component({
+    tag: 'kompendium-anchor',
+    styleUrl: 'anchor.scss',
+    shadow: true,
+})
+export class Anchor {
+    /**
+     * Slug used as the URL anchor fragment and scroll target.
+     */
+    @Prop()
+    public slug: string;
+
+    /**
+     * Human-readable label for the target, used for the aria-label.
+     */
+    @Prop()
+    public label: string;
+
+    @State()
+    private active = false;
+
+    constructor() {
+        this.handleHashChange = this.handleHashChange.bind(this);
+    }
+
+    public connectedCallback(): void {
+        this.updateActive();
+        window.addEventListener('hashchange', this.handleHashChange);
+    }
+
+    public disconnectedCallback(): void {
+        window.removeEventListener('hashchange', this.handleHashChange);
+    }
+
+    public render(): HTMLElement {
+        return (
+            <a
+                class={{ anchor: true, active: this.active }}
+                href={anchorHref(this.slug)}
+                aria-label={`Link to ${this.label}`}
+                onClick={this.handleClick}
+            >
+                ¶
+            </a>
+        );
+    }
+
+    private handleClick = (event: MouseEvent): void => {
+        if (!this.active) {
+            return;
+        }
+
+        event.preventDefault();
+        const url = new URL(window.location.href);
+        url.hash = currentRoute();
+        history.replaceState(history.state, '', url);
+        this.updateActive();
+    };
+
+    private handleHashChange(): void {
+        this.updateActive();
+    }
+
+    private updateActive(): void {
+        this.active = getAnchorId() === this.slug;
+    }
+}

--- a/src/components/component-title.ts
+++ b/src/components/component-title.ts
@@ -1,0 +1,10 @@
+/**
+ * Get a human readable title for a component, e.g. `my-button` => `Button`
+ * @param {string} tag the tag name of the component
+ * @returns {string} the title of the component
+ */
+export function getComponentTitle(tag: string): string {
+    const title = tag.split('-').slice(1).join(' ');
+
+    return title[0].toLocaleUpperCase() + title.slice(1);
+}

--- a/src/components/component/anchors.spec.ts
+++ b/src/components/component/anchors.spec.ts
@@ -1,0 +1,130 @@
+import {
+    anchorHref,
+    currentRoute,
+    entrySlug,
+    exampleAnchorId,
+    firstLine,
+    slugify,
+    uniqueExampleSlugs,
+} from './anchors';
+
+describe('anchors', () => {
+    describe('slugify', () => {
+        it('splits camelCase into dash-separated lowercase', () => {
+            expect(slugify('myProperty')).toEqual('my-property');
+        });
+
+        it('replaces runs of non-alphanumerics with a single dash', () => {
+            expect(slugify('--lime-color__primary')).toEqual(
+                'lime-color-primary',
+            );
+        });
+
+        it('trims leading and trailing dashes', () => {
+            expect(slugify('  Hello, World!  ')).toEqual('hello-world');
+        });
+
+        it('lowercases acronyms', () => {
+            expect(slugify('HTML')).toEqual('html');
+        });
+    });
+
+    describe('firstLine', () => {
+        it('returns the first non-empty trimmed line', () => {
+            expect(firstLine('\n\n  Title here  \nbody')).toEqual('Title here');
+        });
+
+        it('returns an empty string for blank input', () => {
+            expect(firstLine('   \n  \n')).toEqual('');
+        });
+
+        it('handles null/undefined input', () => {
+            expect(firstLine(undefined as unknown as string)).toEqual('');
+        });
+    });
+
+    describe('exampleAnchorId', () => {
+        it('derives the id from the first line of the docs', () => {
+            expect(exampleAnchorId('Basic example\nmore', 'my-tag')).toEqual(
+                'basic-example',
+            );
+        });
+
+        it('falls back to the tag when the docs have no title', () => {
+            expect(exampleAnchorId('  \n ', 'my-example-tag')).toEqual(
+                'my-example-tag',
+            );
+        });
+    });
+
+    describe('entrySlug', () => {
+        it('combines the section slug with a slugified name', () => {
+            expect(entrySlug('properties', 'myValue')).toEqual(
+                'properties-my-value',
+            );
+        });
+    });
+
+    describe('uniqueExampleSlugs', () => {
+        it('keeps distinct slugs unchanged', () => {
+            const result = uniqueExampleSlugs([
+                { docs: 'First', tag: 'a' },
+                { docs: 'Second', tag: 'b' },
+            ]);
+            expect(result).toEqual(['first', 'second']);
+        });
+
+        it('appends numeric suffixes when slugs collide', () => {
+            const result = uniqueExampleSlugs([
+                { docs: 'Same title', tag: 'a' },
+                { docs: 'Same title', tag: 'b' },
+                { docs: 'Same title', tag: 'c' },
+            ]);
+            expect(result).toEqual([
+                'same-title',
+                'same-title-2',
+                'same-title-3',
+            ]);
+        });
+
+        it('uses the tag fallback before deduplicating', () => {
+            const result = uniqueExampleSlugs([
+                { docs: '', tag: 'my-example' },
+                { docs: '', tag: 'my-example' },
+            ]);
+            expect(result).toEqual(['my-example', 'my-example-2']);
+        });
+    });
+
+    describe('currentRoute / anchorHref', () => {
+        const setHash = (hash: string) => {
+            window.location.hash = hash;
+        };
+
+        afterEach(() => {
+            setHash('');
+        });
+
+        it('returns the whole route when there is no secondary anchor', () => {
+            setHash('#/component/my-component/');
+            expect(currentRoute()).toEqual('/component/my-component/');
+        });
+
+        it('strips the trailing #fragment from the route', () => {
+            setHash('#/component/my-component#basic-example');
+            expect(currentRoute()).toEqual('/component/my-component');
+        });
+
+        it('returns an empty route when the hash is empty', () => {
+            setHash('');
+            expect(currentRoute()).toEqual('');
+        });
+
+        it('builds an href preserving the route and adding the slug', () => {
+            setHash('#/component/my-component#old-anchor');
+            expect(anchorHref('new-anchor')).toEqual(
+                '#/component/my-component#new-anchor',
+            );
+        });
+    });
+});

--- a/src/components/component/anchors.ts
+++ b/src/components/component/anchors.ts
@@ -1,0 +1,107 @@
+/**
+ * Slug identifiers used by the table-of-contents and URL anchors on the
+ * component docs page. Kept separate so the component and its templates
+ * can share the same strings.
+ */
+export const SECTION_SLUGS = {
+    examples: 'examples',
+    properties: 'properties',
+    events: 'events',
+    methods: 'methods',
+    slots: 'slots',
+    styles: 'styles',
+} as const;
+
+export type SectionSlug = (typeof SECTION_SLUGS)[keyof typeof SECTION_SLUGS];
+
+/**
+ * Return the first non-empty line of a text blob, trimmed. Returns an
+ * empty string if no non-empty line is found.
+ * @param {string} text the input text
+ * @returns {string} the first non-empty line
+ */
+export function firstLine(text: string): string {
+    const found = (text || '')
+        .split('\n')
+        .find((line) => line.trim().length > 0);
+
+    return found ? found.trim() : '';
+}
+
+/**
+ * Derive an anchor id for an example component from its title (first line
+ * of its docs). Falls back to the example's tag if no title is available.
+ * @param {string} docs the example's docs text
+ * @param {string} fallbackTag tag to slugify if the docs have no title
+ * @returns {string} the anchor id to use in the URL hash
+ */
+export function exampleAnchorId(docs: string, fallbackTag: string): string {
+    return slugify(firstLine(docs)) || slugify(fallbackTag);
+}
+
+/**
+ * Read the current route part of the URL hash, stripping any trailing
+ * `#fragment` anchor.
+ * @returns {string} the route, without leading `#`
+ */
+export function currentRoute(): string {
+    const hash = window.location.hash.replace(/^#/, '');
+    const separatorIndex = hash.indexOf('#');
+
+    return separatorIndex === -1 ? hash : hash.substring(0, separatorIndex);
+}
+
+/**
+ * Build an `href` that preserves the current route and adds a secondary
+ * `#slug` anchor, e.g. `#/component/my-component#basic-example`.
+ * @param {string} slug the anchor id to link to
+ * @returns {string} the full href value
+ */
+export function anchorHref(slug: string): string {
+    return `#${currentRoute()}#${slug}`;
+}
+
+/**
+ * Turn an arbitrary identifier (camelCase, CSS custom property, etc.) into
+ * a URL-safe slug.
+ * @param {string} name the identifier to slugify
+ * @returns {string} the slugified identifier
+ */
+export function slugify(name: string): string {
+    return name
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Build a slug for an entry nested under a section, e.g. `properties-value`.
+ * @param {string} sectionSlug the section slug
+ * @param {string} name the entry name
+ * @returns {string} the combined slug
+ */
+export function entrySlug(sectionSlug: string, name: string): string {
+    return `${sectionSlug}-${slugify(name)}`;
+}
+
+/**
+ * Compute unique anchor ids for a list of example components, appending
+ * `-2`, `-3`, ... suffixes when two examples would otherwise collide on
+ * the same slug (e.g. two examples share a title).
+ * @param {Array<{docs: string; tag: string}>} examples the examples in render order
+ * @returns {string[]} unique slugs in the same order
+ */
+export function uniqueExampleSlugs(
+    examples: Array<{ docs: string; tag: string }>,
+): string[] {
+    const counts = new Map<string, number>();
+
+    return examples.map((example) => {
+        const base = exampleAnchorId(example.docs, example.tag);
+        const count = counts.get(base) || 0;
+        counts.set(base, count + 1);
+
+        return count === 0 ? base : `${base}-${count + 1}`;
+    });
+}

--- a/src/components/component/component.scss
+++ b/src/components/component/component.scss
@@ -16,3 +16,19 @@
         max-width: functions.pxToRem(960);
     }
 }
+
+.section-anchor {
+    display: block;
+    height: 0;
+    width: 0;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.docs-layout-section-heading:hover,
+.props-events-layout h4:hover,
+.methods-title:hover,
+.styles-title:hover,
+.docs h4:hover {
+    --kompendium-anchor-opacity: 1;
+}

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -13,7 +13,21 @@ import { StyleList } from './templates/style';
 import { ExampleList } from './templates/examples';
 import negate from 'lodash/negate';
 import { PropsFactory } from '../playground/playground.types';
-import { getRoute, scrollToElement } from '../anchor-scroll';
+import {
+    getAnchorId,
+    getRoute,
+    scrollToAnchor,
+    scrollToElement,
+} from '../anchor-scroll';
+import {
+    SECTION_SLUGS,
+    entrySlug,
+    firstLine,
+    slugify,
+    uniqueExampleSlugs,
+} from './anchors';
+import { slotDisplayName } from './slots';
+import { TocEntry } from '../toc/toc.types';
 import { getComponentTitle } from '../component-title';
 
 @Component({
@@ -64,64 +78,100 @@ export class KompendiumComponent {
     }
 
     protected componentDidLoad(): void {
-        const route = getRoute().split('#')[0];
-        scrollToElement(this.host.shadowRoot, route);
+        scrollToAnchor(this.host.shadowRoot);
     }
 
     protected componentDidUpdate(): void {
         if (this.scrollToOnNextUpdate) {
-            const route = this.scrollToOnNextUpdate.split('#')[0];
-            scrollToElement(this.host.shadowRoot, route);
+            scrollToElement(this.host.shadowRoot, this.scrollToOnNextUpdate);
             this.scrollToOnNextUpdate = null;
         }
     }
 
     private handleRouteChange() {
-        this.scrollToOnNextUpdate = getRoute().split('#')[0];
+        this.scrollToOnNextUpdate = this.getScrollTargetId();
+        scrollToAnchor(this.host.shadowRoot);
+    }
+
+    private getScrollTargetId(): string | null {
+        return getAnchorId() || getRoute().split('#')[0] || null;
     }
 
     public render(): HTMLElement {
         const tag = this.match.params.name;
         const component = findComponent(tag, this.docs);
+        const examples = findExamples(component, this.docs).filter(
+            (example): example is JsonDocsComponent => Boolean(example),
+        );
+        const exampleSlugs = uniqueExampleSlugs(examples);
 
         return (
             <article class="component">
                 <section class="docs">
-                    {this.renderDocs(tag, component)}
+                    {this.renderDocs(tag, component, examples, exampleSlugs)}
                 </section>
+                <kompendium-toc
+                    entries={buildTocEntries(component, examples, exampleSlugs)}
+                />
             </article>
         );
     }
 
-    private renderDocs(tag: string, component: JsonDocsComponent) {
+    private renderDocs(
+        tag: string,
+        component: JsonDocsComponent,
+        examples: JsonDocsComponent[],
+        exampleSlugs: string[],
+    ) {
         const title = getComponentTitle(tag);
-        const examples = findExamples(component, this.docs);
         const tags = component.docsTags
             .filter(negate(isTag('slot')))
             .filter(negate(isTag('exampleComponent')));
         const schema = this.schemas.find((s) => s.$id === tag);
 
+        // Each section carries two ids by design: a legacy route-based id on
+        // the heading (e.g. `component/<tag>/examples/`, kept so existing
+        // sidebar links and `scrollToElement` keep working) and a short,
+        // URL-fragment-safe `slugId` on a sibling section-anchor span (the
+        // target for the in-page TOC and ¶ anchors). The route-based id cannot
+        // double as a hash fragment, hence both coexist.
         return [
             <h1 id={this.getId()}>{title}</h1>,
             <kompendium-markdown text={component.docs} />,
             <kompendium-taglist tags={tags} />,
             <ExampleList
                 examples={examples}
+                slugs={exampleSlugs}
                 id={this.getId('examples')}
+                slugId={SECTION_SLUGS.examples}
                 schema={schema}
                 propsFactory={this.examplePropsFactory}
             />,
             <PropertyList
                 props={component.props}
                 id={this.getId('properties')}
+                slugId={SECTION_SLUGS.properties}
             />,
-            <EventList events={component.events} id={this.getId('events')} />,
+            <EventList
+                events={component.events}
+                id={this.getId('events')}
+                slugId={SECTION_SLUGS.events}
+            />,
             <MethodList
                 methods={component.methods}
                 id={this.getId('methods')}
+                slugId={SECTION_SLUGS.methods}
             />,
-            <SlotList slots={component.slots} id={this.getId('slots')} />,
-            <StyleList styles={component.styles} id={this.getId('styles')} />,
+            <SlotList
+                slots={component.slots}
+                id={this.getId('slots')}
+                slugId={SECTION_SLUGS.slots}
+            />,
+            <StyleList
+                styles={component.styles}
+                id={this.getId('styles')}
+                slugId={SECTION_SLUGS.styles}
+            />,
         ];
     }
 
@@ -149,3 +199,116 @@ const findComponentByTag = (docs: JsonDocs) => (tag: JsonDocsTag) => {
 const isTag = (name: string) => (tag: JsonDocsTag) => {
     return tag.name === name;
 };
+
+function buildTocEntries(
+    component: JsonDocsComponent,
+    examples: JsonDocsComponent[],
+    exampleSlugs: string[],
+): TocEntry[] {
+    const entries: TocEntry[] = [];
+
+    if (examples.length) {
+        entries.push({
+            id: SECTION_SLUGS.examples,
+            title: 'Examples',
+            collapsible: true,
+            defaultExpanded: true,
+            children: examples.map((example, index) => {
+                const id = exampleSlugs[index];
+                const title =
+                    exampleTitle(example) || prettifyTag(slugify(example.tag));
+
+                return { id: id, title: title };
+            }),
+        });
+    }
+
+    if (component.props?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.properties,
+                'Properties',
+                component.props.map((prop) => prop.name),
+            ),
+        );
+    }
+
+    if (component.events?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.events,
+                'Events',
+                component.events.map((event) => event.event),
+            ),
+        );
+    }
+
+    if (component.methods?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.methods,
+                'Methods',
+                component.methods.map((method) => method.name),
+            ),
+        );
+    }
+
+    if (component.slots?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.slots,
+                'Slots',
+                component.slots.map((slot) => slotDisplayName(slot.name)),
+            ),
+        );
+    }
+
+    if (component.styles?.length) {
+        entries.push(
+            collapsibleSection(
+                SECTION_SLUGS.styles,
+                'Styles',
+                component.styles.map((style) => style.name),
+            ),
+        );
+    }
+
+    return entries;
+}
+
+function collapsibleSection(
+    sectionSlug: string,
+    title: string,
+    names: string[],
+): TocEntry {
+    return {
+        id: sectionSlug,
+        title: title,
+        collapsible: true,
+        children: names.map((name) => ({
+            id: entrySlug(sectionSlug, name),
+            title: name,
+        })),
+    };
+}
+
+function exampleTitle(example: JsonDocsComponent): string {
+    return firstLine(example.docs);
+}
+
+function prettifyTag(slug: string): string {
+    if (!slug) {
+        return slug;
+    }
+
+    const words = slug.split('-').filter(Boolean);
+    if (!words.length) {
+        return slug;
+    }
+
+    return (
+        words[0][0].toLocaleUpperCase() +
+        words[0].substring(1) +
+        (words.length > 1 ? ' ' + words.slice(1).join(' ') : '')
+    );
+}

--- a/src/components/component/component.tsx
+++ b/src/components/component/component.tsx
@@ -14,6 +14,7 @@ import { ExampleList } from './templates/examples';
 import negate from 'lodash/negate';
 import { PropsFactory } from '../playground/playground.types';
 import { getRoute, scrollToElement } from '../anchor-scroll';
+import { getComponentTitle } from '../component-title';
 
 @Component({
     tag: 'kompendium-component',
@@ -93,8 +94,7 @@ export class KompendiumComponent {
     }
 
     private renderDocs(tag: string, component: JsonDocsComponent) {
-        let title = tag.split('-').slice(1).join(' ');
-        title = title[0].toLocaleUpperCase() + title.slice(1);
+        const title = getComponentTitle(tag);
         const examples = findExamples(component, this.docs);
         const tags = component.docsTags
             .filter(negate(isTag('slot')))

--- a/src/components/component/slots.ts
+++ b/src/components/component/slots.ts
@@ -1,0 +1,10 @@
+/**
+ * Stencil reports a component's unnamed (default) slot with an empty
+ * string name. Normalize to a user-facing label so it renders and
+ * slugifies consistently across the docs page and the TOC.
+ * @param {string} name the raw slot name from JsonDocs
+ * @returns {string} the display name to use for headings and TOC entries
+ */
+export function slotDisplayName(name: string): string {
+    return name || 'default';
+}

--- a/src/components/component/templates/events.tsx
+++ b/src/components/component/templates/events.tsx
@@ -1,12 +1,15 @@
 import { JsonDocsEvent } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { ProplistItem } from '../../proplist/proplist';
+import { entrySlug } from '../anchors';
 
 export function EventList({
     events,
     id,
+    slugId,
 }: {
-    id: string;
+    id?: string;
+    slugId?: string;
     events: JsonDocsEvent[];
 }): HTMLElement[] {
     if (!events.length) {
@@ -14,41 +17,53 @@ export function EventList({
     }
 
     return [
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h3 class="docs-layout-section-heading" id={id}>
             Events
+            {slugId ? <kompendium-anchor slug={slugId} label="Events" /> : null}
         </h3>,
-        ...events.map(renderEvent),
+        ...events.map(renderEvent(slugId)),
     ];
 }
 
-function renderEvent(event: JsonDocsEvent) {
-    const items: ProplistItem[] = [
-        {
-            key: 'Detail',
-            value: event.detail,
-        },
-        {
-            key: 'Bubbles',
-            value: String(event.bubbles),
-        },
-        {
-            key: 'Cancelable',
-            value: String(event.cancelable),
-        },
-        {
-            key: 'Composed',
-            value: String(event.composed),
-        },
-    ];
+const renderEvent =
+    (sectionSlug: string | undefined) => (event: JsonDocsEvent) => {
+        const items: ProplistItem[] = [
+            {
+                key: 'Detail',
+                value: event.detail,
+            },
+            {
+                key: 'Bubbles',
+                value: String(event.bubbles),
+            },
+            {
+                key: 'Cancelable',
+                value: String(event.cancelable),
+            },
+            {
+                key: 'Composed',
+                value: String(event.composed),
+            },
+        ];
 
-    return (
-        <div class="props-events-layout">
-            <h4>{event.event}</h4>
-            <kompendium-taglist tags={event.docsTags} />
-            <div class="markdown-props">
-                <kompendium-markdown text={event.docs} />
-                <kompendium-proplist items={items} />
+        const slug = sectionSlug ? entrySlug(sectionSlug, event.event) : null;
+
+        return (
+            <div class="props-events-layout">
+                <h4 id={slug}>
+                    {event.event}
+                    {slug ? (
+                        <kompendium-anchor slug={slug} label={event.event} />
+                    ) : null}
+                </h4>
+                <kompendium-taglist tags={event.docsTags} />
+                <div class="markdown-props">
+                    <kompendium-markdown text={event.docs} />
+                    <kompendium-proplist items={items} />
+                </div>
             </div>
-        </div>
-    );
-}
+        );
+    };

--- a/src/components/component/templates/examples.spec.tsx
+++ b/src/components/component/templates/examples.spec.tsx
@@ -18,7 +18,9 @@ describe('ExampleList', () => {
                 <div>
                     <ExampleList
                         examples={[example]}
+                        slugs={['examples']}
                         id="component/my-component/examples/"
+                        slugId="examples"
                         schema={undefined}
                     />
                 </div>
@@ -40,7 +42,9 @@ describe('ExampleList', () => {
                 <div>
                     <ExampleList
                         examples={[example]}
+                        slugs={['examples']}
                         id="component/my-component/examples/"
+                        slugId="examples"
                         schema={undefined}
                     />
                 </div>

--- a/src/components/component/templates/examples.spec.tsx
+++ b/src/components/component/templates/examples.spec.tsx
@@ -1,0 +1,56 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { JsonDocsComponent } from '@stencil/core/internal';
+import { h } from '@stencil/core';
+import { ExampleList } from './examples';
+import { Playground } from '../../playground/playground';
+
+const example: JsonDocsComponent = {
+    tag: 'my-component-example',
+    docs: 'Basic example',
+    docsTags: [],
+} as any;
+
+describe('ExampleList', () => {
+    it('renders the section heading as an h2', async () => {
+        const page = await newSpecPage({
+            components: [Playground],
+            template: () => (
+                <div>
+                    <ExampleList
+                        examples={[example]}
+                        id="component/my-component/examples/"
+                        schema={undefined}
+                    />
+                </div>
+            ),
+        });
+
+        const heading = page.body.querySelector(
+            'h2.docs-layout-section-heading',
+        );
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toEqual('Examples');
+        expect(heading.id).toEqual('component/my-component/examples/');
+    });
+
+    it('does not render any heading below h2 for the section', async () => {
+        const page = await newSpecPage({
+            components: [Playground],
+            template: () => (
+                <div>
+                    <ExampleList
+                        examples={[example]}
+                        id="component/my-component/examples/"
+                        schema={undefined}
+                    />
+                </div>
+            ),
+        });
+
+        expect(
+            page.body.querySelector(
+                'h3.docs-layout-section-heading, h4.docs-layout-section-heading, h5.docs-layout-section-heading',
+            ),
+        ).toBeNull();
+    });
+});

--- a/src/components/component/templates/examples.tsx
+++ b/src/components/component/templates/examples.tsx
@@ -18,9 +18,9 @@ export function ExampleList({
     }
 
     return [
-        <h3 class="docs-layout-section-heading" id={id}>
+        <h2 class="docs-layout-section-heading" id={id}>
             Examples
-        </h3>,
+        </h2>,
         examples.map(renderExample(schema, propsFactory)),
     ];
 }

--- a/src/components/component/templates/examples.tsx
+++ b/src/components/component/templates/examples.tsx
@@ -4,12 +4,16 @@ import { PropsFactory } from '../../playground/playground.types';
 
 export function ExampleList({
     examples,
+    slugs,
     id,
+    slugId,
     schema,
     propsFactory,
 }: {
-    id: string;
+    id?: string;
+    slugId?: string;
     examples: JsonDocsComponent[];
+    slugs: string[];
     schema: Record<string, any>;
     propsFactory?: PropsFactory;
 }): HTMLElement[] {
@@ -18,22 +22,33 @@ export function ExampleList({
     }
 
     return [
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h2 class="docs-layout-section-heading" id={id}>
             Examples
+            {slugId ? (
+                <kompendium-anchor slug={slugId} label="Examples" />
+            ) : null}
         </h2>,
-        examples.map(renderExample(schema, propsFactory)),
+        examples.map(renderExample(slugs, schema, propsFactory)),
     ];
 }
 
 const renderExample =
-    (schema: Record<string, any>, factory: PropsFactory) =>
-    (example: JsonDocsComponent) => {
+    (slugs: string[], schema: Record<string, any>, factory: PropsFactory) =>
+    (example: JsonDocsComponent, index: number) => {
+        const slug = slugs[index];
+
         return (
-            <kompendium-playground
-                component={example}
-                schema={schema}
-                propsFactory={factory}
-            />
+            <div class="example-wrapper" id={slug}>
+                <kompendium-playground
+                    anchorSlug={slug}
+                    component={example}
+                    schema={schema}
+                    propsFactory={factory}
+                />
+            </div>
         );
     };
 

--- a/src/components/component/templates/methods.tsx
+++ b/src/components/component/templates/methods.tsx
@@ -6,12 +6,15 @@ import {
 import { h } from '@stencil/core';
 import { ProplistItem } from '../../proplist/proplist';
 import { ParameterDescription } from '../../../types';
+import { entrySlug } from '../anchors';
 
 export function MethodList({
     methods,
     id,
+    slugId,
 }: {
     id?: string;
+    slugId?: string;
     methods: Array<Partial<JsonDocsMethod>>;
 }): HTMLElement[] {
     if (!methods.length) {
@@ -19,40 +22,53 @@ export function MethodList({
     }
 
     return [
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h3 class="docs-layout-section-heading" id={id}>
             Methods
+            {slugId ? (
+                <kompendium-anchor slug={slugId} label="Methods" />
+            ) : null}
         </h3>,
-        ...methods.map(renderMethod),
+        ...methods.map(renderMethod(slugId)),
     ];
 }
 
-function renderMethod(method: JsonDocsMethod) {
-    const items: ProplistItem[] = [
-        {
-            key: 'Signature',
-            value: method.signature,
-        },
-    ].filter((item) => item.value !== undefined);
+const renderMethod =
+    (sectionSlug: string | undefined) => (method: JsonDocsMethod) => {
+        const items: ProplistItem[] = [
+            {
+                key: 'Signature',
+                value: method.signature,
+            },
+        ].filter((item) => item.value !== undefined);
+        const slug = sectionSlug ? entrySlug(sectionSlug, method.name) : null;
 
-    return (
-        <div class="methods-layout">
-            <h4 class="methods-title">{method.name}</h4>
-            <div class="methods-content">
-                <div>
-                    <kompendium-markdown text={method.docs} />
+        return (
+            <div class="methods-layout">
+                <h4 class="methods-title" id={slug}>
+                    {method.name}
+                    {slug ? (
+                        <kompendium-anchor slug={slug} label={method.name} />
+                    ) : null}
+                </h4>
+                <div class="methods-content">
+                    <div>
+                        <kompendium-markdown text={method.docs} />
+                    </div>
+                    <div>
+                        <kompendium-taglist tags={method.docsTags} />
+                        <kompendium-proplist items={items} />
+                        <ParamList params={method.parameters} />
+                    </div>
                 </div>
-                <div>
-                    <kompendium-taglist tags={method.docsTags} />
-                    <kompendium-proplist items={items} />
-                    <ParamList params={method.parameters} />
+                <div class="methods-returns">
+                    <Returns value={method.returns} />
                 </div>
             </div>
-            <div class="methods-returns">
-                <Returns value={method.returns} />
-            </div>
-        </div>
-    );
-}
+        );
+    };
 
 function ParamList({ params }: { params: JsonDocMethodParameter[] }) {
     if (!params.length) {

--- a/src/components/component/templates/props.tsx
+++ b/src/components/component/templates/props.tsx
@@ -1,12 +1,15 @@
 import { JsonDocsProp } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { ProplistItem } from '../../proplist/proplist';
+import { entrySlug } from '../anchors';
 
 export function PropertyList({
     props,
     id,
+    slugId,
 }: {
     id?: string;
+    slugId?: string;
     props: Array<Partial<JsonDocsProp>>;
 }): HTMLElement[] {
     if (!props.length) {
@@ -14,45 +17,61 @@ export function PropertyList({
     }
 
     return [
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h3 class="docs-layout-section-heading" id={id}>
             Properties
+            {slugId ? (
+                <kompendium-anchor slug={slugId} label="Properties" />
+            ) : null}
         </h3>,
-        ...props.map(renderProperty),
+        ...props.map(renderProperty(slugId)),
     ];
 }
 
-function renderProperty(property: JsonDocsProp) {
-    const items: ProplistItem[] = [
-        {
-            key: 'Type',
-            value: property.type,
-        },
-        {
-            key: 'Attribute name',
-            value: property.attr,
-        },
-        {
-            key: 'Default value',
-            value: property.default,
-        },
-        {
-            key: 'Optional',
-            value: String(property.optional),
-        },
-        {
-            key: 'Required',
-            value: String(property.required),
-        },
-    ].filter((item) => item.value !== undefined && item.value !== 'undefined');
+const renderProperty =
+    (sectionSlug: string | undefined) => (property: JsonDocsProp) => {
+        const items: ProplistItem[] = [
+            {
+                key: 'Type',
+                value: property.type,
+            },
+            {
+                key: 'Attribute name',
+                value: property.attr,
+            },
+            {
+                key: 'Default value',
+                value: property.default,
+            },
+            {
+                key: 'Optional',
+                value: String(property.optional),
+            },
+            {
+                key: 'Required',
+                value: String(property.required),
+            },
+        ].filter(
+            (item) => item.value !== undefined && item.value !== 'undefined',
+        );
 
-    return (
-        <div class="props-events-layout">
-            <h4>{property.name}</h4>
-            <kompendium-taglist tags={property.docsTags} />
-            <div class="markdown-props">
-                <kompendium-markdown text={property.docs} />
-                <kompendium-proplist items={items} />
+        const slug = sectionSlug ? entrySlug(sectionSlug, property.name) : null;
+
+        return (
+            <div class="props-events-layout">
+                <h4 id={slug}>
+                    {property.name}
+                    {slug ? (
+                        <kompendium-anchor slug={slug} label={property.name} />
+                    ) : null}
+                </h4>
+                <kompendium-taglist tags={property.docsTags} />
+                <div class="markdown-props">
+                    <kompendium-markdown text={property.docs} />
+                    <kompendium-proplist items={items} />
+                </div>
             </div>
-        </div>
-    );
-}
+        );
+    };

--- a/src/components/component/templates/slots.tsx
+++ b/src/components/component/templates/slots.tsx
@@ -1,11 +1,15 @@
 import { JsonDocsSlot } from '@stencil/core/internal';
 import { h } from '@stencil/core';
+import { entrySlug } from '../anchors';
+import { slotDisplayName } from '../slots';
 
 export function SlotList({
     slots,
     id,
+    slugId,
 }: {
-    id: string;
+    id?: string;
+    slugId?: string;
     slots: JsonDocsSlot[];
 }): HTMLElement[] {
     if (!slots.length) {
@@ -13,18 +17,31 @@ export function SlotList({
     }
 
     return [
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h3 class="docs-layout-section-heading" id={id}>
             Slots
+            {slugId ? <kompendium-anchor slug={slugId} label="Slots" /> : null}
         </h3>,
-        ...slots.map(renderSlot),
+        ...slots.map(renderSlot(slugId)),
     ];
 }
 
-function renderSlot(slot: JsonDocsSlot) {
-    return (
-        <div>
-            <h4>{slot.name}</h4>
-            <kompendium-markdown text={slot.docs} />
-        </div>
-    );
-}
+const renderSlot =
+    (sectionSlug: string | undefined) => (slot: JsonDocsSlot) => {
+        const name = slotDisplayName(slot.name);
+        const slug = sectionSlug ? entrySlug(sectionSlug, name) : null;
+
+        return (
+            <div>
+                <h4 id={slug}>
+                    {name}
+                    {slug ? (
+                        <kompendium-anchor slug={slug} label={name} />
+                    ) : null}
+                </h4>
+                <kompendium-markdown text={slot.docs} />
+            </div>
+        );
+    };

--- a/src/components/component/templates/style.tsx
+++ b/src/components/component/templates/style.tsx
@@ -1,11 +1,14 @@
 import { JsonDocsStyle } from '@stencil/core/internal';
 import { h } from '@stencil/core';
+import { entrySlug } from '../anchors';
 
 export function StyleList({
     styles,
     id,
+    slugId,
 }: {
-    id: string;
+    id?: string;
+    slugId?: string;
     styles: JsonDocsStyle[];
 }): HTMLElement[] {
     if (!styles.length) {
@@ -13,22 +16,32 @@ export function StyleList({
     }
 
     return [
+        slugId ? (
+            <span class="section-anchor" id={slugId} aria-hidden="true"></span>
+        ) : null,
         <h3 class="docs-layout-section-heading" id={id}>
             Styles
+            {slugId ? <kompendium-anchor slug={slugId} label="Styles" /> : null}
         </h3>,
-        ...styles.map(renderStyle),
+        ...styles.map(renderStyle(slugId)),
     ];
 }
 
-function renderStyle(style: JsonDocsStyle) {
-    return (
-        <div class="styles-layout">
-            <div class="styles-title">
-                <code>{style.name}</code>
+const renderStyle =
+    (sectionSlug: string | undefined) => (style: JsonDocsStyle) => {
+        const slug = sectionSlug ? entrySlug(sectionSlug, style.name) : null;
+
+        return (
+            <div class="styles-layout">
+                <div class="styles-title" id={slug}>
+                    <code>{style.name}</code>
+                    {slug ? (
+                        <kompendium-anchor slug={slug} label={style.name} />
+                    ) : null}
+                </div>
+                <div class="styles-content">
+                    <kompendium-markdown text={style.docs} />
+                </div>
             </div>
-            <div class="styles-content">
-                <kompendium-markdown text={style.docs} />
-            </div>
-        </div>
-    );
-}
+        );
+    };

--- a/src/components/debug/debug.scss
+++ b/src/components/debug/debug.scss
@@ -1,0 +1,21 @@
+@use '../../style/functions.scss';
+
+// The context headings exist to give the debug page the same heading
+// outline as the component page; visually they are deliberately small,
+// since the example component is the main content here.
+.context-heading {
+    margin: 0;
+    font-weight: 500;
+    color: rgb(var(--kompendium-contrast-900));
+}
+
+h2.context-heading {
+    font-size: functions.pxToRem(14);
+    line-height: functions.pxToRem(20);
+}
+
+h3.context-heading {
+    font-size: functions.pxToRem(12);
+    line-height: functions.pxToRem(16);
+    margin-bottom: functions.pxToRem(8);
+}

--- a/src/components/debug/debug.spec.tsx
+++ b/src/components/debug/debug.spec.tsx
@@ -1,0 +1,55 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { JsonDocs } from '@stencil/core/internal';
+import { h } from '@stencil/core';
+import { KompendiumDebug } from './debug';
+
+const docs: JsonDocs = {
+    components: [
+        {
+            tag: 'my-button',
+            docs: 'A button.',
+            docsTags: [
+                {
+                    name: 'exampleComponent',
+                    text: 'my-button-example',
+                },
+            ],
+        },
+        {
+            tag: 'my-button-example',
+            docs: 'Basic button\n\nA longer description.',
+            docsTags: [],
+        },
+    ],
+} as any;
+
+async function createPage() {
+    return newSpecPage({
+        components: [KompendiumDebug],
+        template: () => (
+            <kompendium-debug
+                docs={docs}
+                schemas={[{ $id: 'my-button' }]}
+                match={{ params: { name: 'my-button-example' } } as any}
+            />
+        ),
+    });
+}
+
+describe('kompendium-debug', () => {
+    it('renders the component name as an h2 heading', async () => {
+        const page = await createPage();
+
+        const heading = page.root.shadowRoot.querySelector('h2');
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toEqual('Button');
+    });
+
+    it('renders the example title as an h3 heading', async () => {
+        const page = await createPage();
+
+        const heading = page.root.shadowRoot.querySelector('h3');
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toEqual('Basic button');
+    });
+});

--- a/src/components/debug/debug.tsx
+++ b/src/components/debug/debug.tsx
@@ -6,9 +6,11 @@ import {
 } from '@stencil/core/internal';
 import { MatchResults } from '@limetech/stencil-router';
 import { PropsFactory } from '../playground/playground.types';
+import { getComponentTitle } from '../component-title';
 
 @Component({
     tag: 'kompendium-debug',
+    styleUrl: 'debug.scss',
     shadow: true,
 })
 export class KompendiumDebug {
@@ -60,13 +62,33 @@ export class KompendiumDebug {
             ...factory(ExampleComponent),
         };
 
-        return (
+        return [
+            this.renderHeadings(component, ownerComponent),
             <div class="show-case">
                 <div class="show-case_component">
                     <ExampleComponent {...props} />
                 </div>
-            </div>
-        );
+            </div>,
+        ];
+    }
+
+    /*
+     * Render the same heading context as the component page, so that the
+     * heading outline of an example is identical on both pages, e.g. when
+     * testing for accessibility
+     */
+    private renderHeadings(
+        component: JsonDocsComponent,
+        ownerComponent: JsonDocsComponent,
+    ) {
+        const exampleTitle = component.docs?.split('\n')[0];
+
+        return [
+            <h2 class="context-heading">
+                {getComponentTitle(ownerComponent.tag)}
+            </h2>,
+            !!exampleTitle && <h3 class="context-heading">{exampleTitle}</h3>,
+        ];
     }
 }
 

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -117,3 +117,15 @@ blockquote {
     color: rgb(var(--kompendium-contrast-1100));
     padding-left: 1rem;
 }
+
+h3 {
+    // The custom properties let the playground keep the example title at
+    // the size it had back when it was an h5; the fallbacks match the
+    // regular h3 styles in typography.scss.
+    font-size: var(--kompendium-markdown-h3-font-size, functions.pxToRem(22));
+    line-height: var(
+        --kompendium-markdown-h3-line-height,
+        functions.pxToRem(24)
+    );
+    margin-top: var(--kompendium-markdown-h3-margin-top, functions.pxToRem(16));
+}

--- a/src/components/playground/playground.scss
+++ b/src/components/playground/playground.scss
@@ -193,6 +193,17 @@ section.example {
     --kompendium-markdown-h3-margin-top: #{functions.pxToRem(12)};
 }
 
+.example-heading {
+    margin: 0 0 functions.pxToRem(12) 0;
+    font-size: functions.pxToRem(18);
+    line-height: functions.pxToRem(18);
+    font-weight: 500;
+
+    &:hover {
+        --kompendium-anchor-opacity: 1;
+    }
+}
+
 .show-case_component {
     font-family: var(--kompendium-example-font-family, inherit);
     font-size: var(--kompendium-example-font-size, inherit);

--- a/src/components/playground/playground.scss
+++ b/src/components/playground/playground.scss
@@ -185,6 +185,12 @@ section.example {
 
 .show-case_description {
     padding: functions.pxToRem(12);
+
+    // The example title is an h3 element for the sake of the document
+    // outline, but keeps the size it had back when it was an h5.
+    --kompendium-markdown-h3-font-size: #{functions.pxToRem(18)};
+    --kompendium-markdown-h3-line-height: #{functions.pxToRem(18)};
+    --kompendium-markdown-h3-margin-top: #{functions.pxToRem(12)};
 }
 
 .show-case_component {

--- a/src/components/playground/playground.spec.tsx
+++ b/src/components/playground/playground.spec.tsx
@@ -1,0 +1,27 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { JsonDocsComponent } from '@stencil/core/internal';
+import { h } from '@stencil/core';
+import { Playground } from './playground';
+
+const example: JsonDocsComponent = {
+    tag: 'my-component-example',
+    docs: 'Basic example\n\nA longer description.',
+    docsTags: [],
+} as any;
+
+describe('kompendium-playground', () => {
+    it('renders the example title as an h3 heading', async () => {
+        const page = await newSpecPage({
+            components: [Playground],
+            template: () => (
+                <kompendium-playground component={example} schema={undefined} />
+            ),
+        });
+
+        const markdown = page.root.shadowRoot.querySelector(
+            'kompendium-markdown',
+        );
+        const text = (markdown as any).text ?? markdown.getAttribute('text');
+        expect(text).toEqual('### Basic example\n\nA longer description.');
+    });
+});

--- a/src/components/playground/playground.spec.tsx
+++ b/src/components/playground/playground.spec.tsx
@@ -2,6 +2,7 @@ import { newSpecPage } from '@stencil/core/testing';
 import { JsonDocsComponent } from '@stencil/core/internal';
 import { h } from '@stencil/core';
 import { Playground } from './playground';
+import { splitDocs } from './split-docs';
 
 const example: JsonDocsComponent = {
     tag: 'my-component-example',
@@ -18,10 +19,62 @@ describe('kompendium-playground', () => {
             ),
         });
 
+        const heading =
+            page.root.shadowRoot.querySelector('h3.example-heading');
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toEqual('Basic example');
+    });
+
+    it('renders the rest of the docs as markdown', async () => {
+        const page = await newSpecPage({
+            components: [Playground],
+            template: () => (
+                <kompendium-playground component={example} schema={undefined} />
+            ),
+        });
+
         const markdown = page.root.shadowRoot.querySelector(
             'kompendium-markdown',
         );
         const text = (markdown as any).text ?? markdown.getAttribute('text');
-        expect(text).toEqual('### Basic example\n\nA longer description.');
+        expect(text).toEqual('A longer description.');
+    });
+});
+
+describe('splitDocs', () => {
+    it('returns empty title and body for empty docs', () => {
+        expect(splitDocs('')).toEqual({ title: '', body: '' });
+    });
+
+    it('returns empty title and body for blank-only docs', () => {
+        expect(splitDocs('\n   \n\t\n')).toEqual({ title: '', body: '' });
+    });
+
+    it('returns empty title and body for null/undefined docs', () => {
+        expect(splitDocs(undefined as unknown as string)).toEqual({
+            title: '',
+            body: '',
+        });
+    });
+
+    it('returns a trimmed title and empty body for a title-only doc', () => {
+        expect(splitDocs('  Just a title  ')).toEqual({
+            title: 'Just a title',
+            body: '',
+        });
+    });
+
+    it('skips leading blank lines when locating the title', () => {
+        expect(splitDocs('\n\n  Title  \nbody line')).toEqual({
+            title: 'Title',
+            body: 'body line',
+        });
+    });
+
+    it('splits the title from a multi-line body', () => {
+        expect(splitDocs('Title\n\nFirst paragraph.\nSecond.')).toEqual({
+            title: 'Title',
+            body: 'First paragraph.\nSecond.',
+        });
     });
 });

--- a/src/components/playground/playground.tsx
+++ b/src/components/playground/playground.tsx
@@ -3,6 +3,7 @@ import { JsonDocsComponent } from '@stencil/core/internal';
 import { JsonDocsSource } from '../../kompendium/source';
 import { Theme, THEME_EVENT_NAME } from '../darkmode-switch/types';
 import { PropsFactory } from './playground.types';
+import { splitDocs } from './split-docs';
 
 @Component({
     tag: 'kompendium-playground',
@@ -28,6 +29,12 @@ export class Playground {
      */
     @Prop()
     public propsFactory?: PropsFactory = () => ({});
+
+    /**
+     * Slug used as the URL anchor for linking to this example.
+     */
+    @Prop()
+    public anchorSlug?: string;
 
     @State()
     private activeTab: string;
@@ -93,17 +100,27 @@ export class Playground {
 
     private renderResult() {
         const ExampleComponent = this.component.tag;
-        const text = '### ' + this.component.docs;
         const factory = this.propsFactory;
         const props = {
             schema: this.schema,
             ...factory(ExampleComponent),
         };
+        const { title, body } = splitDocs(this.component.docs);
+        const heading = title || this.component.tag;
 
         return (
             <div class="show-case">
                 <div class="show-case_description">
-                    <kompendium-markdown text={text} />
+                    <h3 class="example-heading">
+                        {heading}
+                        {this.anchorSlug ? (
+                            <kompendium-anchor
+                                slug={this.anchorSlug}
+                                label={heading}
+                            />
+                        ) : null}
+                    </h3>
+                    {body ? <kompendium-markdown text={body} /> : null}
                 </div>
                 <div class="show-case_component">
                     {this.renderDebugButton(this.component.tag)}

--- a/src/components/playground/playground.tsx
+++ b/src/components/playground/playground.tsx
@@ -93,7 +93,7 @@ export class Playground {
 
     private renderResult() {
         const ExampleComponent = this.component.tag;
-        const text = '##### ' + this.component.docs;
+        const text = '### ' + this.component.docs;
         const factory = this.propsFactory;
         const props = {
             schema: this.schema,

--- a/src/components/playground/split-docs.ts
+++ b/src/components/playground/split-docs.ts
@@ -1,0 +1,25 @@
+import { firstLine } from '../component/anchors';
+
+/**
+ * Split an example's docs into a title (the first non-empty line) and the
+ * remaining body. Kept in a separate module from the kompendium-playground
+ * component so it can be unit-tested directly -- Stencil only allows a
+ * component module to export the component class itself.
+ * @param {string} docs the example's docs text
+ * @returns {{title: string; body: string}} the title and remaining body
+ */
+export function splitDocs(docs: string): { title: string; body: string } {
+    const lines = (docs || '').split('\n');
+    const titleIndex = lines.findIndex((line) => line.trim().length > 0);
+    if (titleIndex === -1) {
+        return { title: '', body: '' };
+    }
+
+    return {
+        title: firstLine(docs),
+        body: lines
+            .slice(titleIndex + 1)
+            .join('\n')
+            .trim(),
+    };
+}

--- a/src/components/toc/toc.scss
+++ b/src/components/toc/toc.scss
@@ -1,0 +1,185 @@
+@use '../../style/functions.scss';
+@use '../../style/variables.scss';
+@use '../../style/mixins.scss';
+
+:host {
+    display: contents;
+    font-family: var(--kompendium-font-primary);
+}
+
+.toc.hidden {
+    display: none;
+}
+
+.fab {
+    position: fixed;
+    top: functions.pxToRem(24);
+    right: functions.pxToRem(24);
+    z-index: 110;
+
+    width: functions.pxToRem(48);
+    height: functions.pxToRem(48);
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+
+    background-color: rgb(var(--kompendium-contrast-200));
+    color: rgb(var(--kompendium-contrast-1100));
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @include mixins.is-elevated-clickable;
+}
+
+.scrim {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background-color: rgba(var(--kompendium-color-black), 0.24);
+    backdrop-filter: blur(functions.pxToRem(2));
+}
+
+.panel {
+    display: none;
+    position: fixed;
+    z-index: 105;
+    right: functions.pxToRem(24);
+    top: functions.pxToRem(84);
+
+    width: min(
+        #{functions.pxToRem(360)},
+        calc(100vw - #{functions.pxToRem(48)})
+    );
+    max-height: calc(100vh - #{functions.pxToRem(120)});
+    overflow-y: auto;
+
+    background-color: rgb(var(--kompendium-contrast-200));
+    color: rgb(var(--kompendium-contrast-1100));
+
+    border-radius: functions.pxToRem(12);
+    box-shadow: var(--kompendium-shadow-depth-16);
+    padding: functions.pxToRem(16) functions.pxToRem(20);
+}
+
+.heading {
+    margin: 0 0 functions.pxToRem(8) 0;
+    font-size: functions.pxToRem(13);
+    font-variant: all-small-caps;
+    letter-spacing: functions.pxToRem(1);
+    color: rgb(var(--kompendium-contrast-900));
+    font-weight: 500;
+}
+
+.entries {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.entry {
+    margin: 0;
+    padding: 0;
+
+    &::before {
+        display: none;
+        content: none;
+    }
+}
+
+.entry-row {
+    display: flex;
+    align-items: center;
+    gap: functions.pxToRem(2);
+}
+
+.toggle {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    width: functions.pxToRem(20);
+    height: functions.pxToRem(20);
+    padding: 0;
+
+    background: transparent;
+    border: none;
+    border-radius: functions.pxToRem(4);
+    cursor: pointer;
+
+    color: rgb(var(--kompendium-contrast-900));
+
+    svg {
+        transition: transform 0.15s ease;
+    }
+
+    &.expanded svg {
+        transform: rotate(90deg);
+    }
+
+    &:hover {
+        background-color: rgba(var(--kompendium-contrast-400), 0.8);
+        color: rgb(var(--kompendium-contrast-1100));
+    }
+
+    @include mixins.visualize-keyboard-focus();
+}
+
+.link {
+    flex: 1;
+    display: block;
+    padding: functions.pxToRem(6) functions.pxToRem(8);
+    border-radius: functions.pxToRem(4);
+    color: rgb(var(--kompendium-contrast-1100));
+    text-decoration: none;
+    font-size: functions.pxToRem(14);
+    line-height: functions.pxToRem(20);
+
+    &:hover {
+        background-color: rgba(var(--kompendium-contrast-400), 0.8);
+        color: rgb(var(--kompendium-color-blue-default));
+    }
+
+    @include mixins.visualize-keyboard-focus();
+}
+
+.children {
+    list-style: none;
+    margin: functions.pxToRem(2) 0 functions.pxToRem(4) functions.pxToRem(12);
+    padding: 0 0 0 functions.pxToRem(12);
+    border-left: 1px solid rgb(var(--kompendium-contrast-500));
+
+    .entry::before {
+        display: none;
+        content: none;
+    }
+
+    .link {
+        font-size: functions.pxToRem(13);
+        color: rgb(var(--kompendium-contrast-1000));
+    }
+}
+
+.toc.open {
+    .scrim,
+    .panel {
+        display: block;
+    }
+}
+
+@media (max-width: variables.$break-point-small) {
+    .panel {
+        right: functions.pxToRem(16);
+        left: functions.pxToRem(16);
+        max-width: none;
+    }
+
+    .fab {
+        top: functions.pxToRem(16);
+        right: functions.pxToRem(16);
+    }
+}

--- a/src/components/toc/toc.spec.tsx
+++ b/src/components/toc/toc.spec.tsx
@@ -1,0 +1,138 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { h } from '@stencil/core';
+import { Toc } from './toc';
+import { collectIds, findAncestorsOf, findEntryById } from './toc.tree';
+import { TocEntry } from './toc.types';
+
+const tree: TocEntry[] = [
+    {
+        id: 'examples',
+        title: 'Examples',
+        collapsible: true,
+        children: [
+            { id: 'basic-example', title: 'Basic example' },
+            { id: 'advanced-example', title: 'Advanced example' },
+        ],
+    },
+    {
+        id: 'properties',
+        title: 'Properties',
+        collapsible: true,
+        children: [{ id: 'properties-value', title: 'value' }],
+    },
+];
+
+describe('toc helpers', () => {
+    describe('collectIds', () => {
+        it('collects every id in the tree, including nested ones', () => {
+            expect([...collectIds(tree)].sort()).toEqual(
+                [
+                    'advanced-example',
+                    'basic-example',
+                    'examples',
+                    'properties',
+                    'properties-value',
+                ].sort(),
+            );
+        });
+
+        it('returns an empty set for an empty list', () => {
+            expect(collectIds([]).size).toEqual(0);
+        });
+    });
+
+    describe('findEntryById', () => {
+        it('finds a top-level entry', () => {
+            expect(findEntryById('properties', tree)?.title).toEqual(
+                'Properties',
+            );
+        });
+
+        it('finds a nested entry', () => {
+            expect(findEntryById('advanced-example', tree)?.title).toEqual(
+                'Advanced example',
+            );
+        });
+
+        it('returns null when no entry matches', () => {
+            expect(findEntryById('missing', tree)).toBeNull();
+        });
+    });
+
+    describe('findAncestorsOf', () => {
+        it('returns the ancestor chain of a nested entry', () => {
+            const ancestors = findAncestorsOf('basic-example', tree).map(
+                (entry) => entry.id,
+            );
+            expect(ancestors).toEqual(['examples']);
+        });
+
+        it('returns an empty chain for a top-level entry', () => {
+            expect(findAncestorsOf('examples', tree)).toEqual([]);
+        });
+
+        it('returns an empty chain for an unknown id', () => {
+            expect(findAncestorsOf('missing', tree)).toEqual([]);
+        });
+    });
+});
+
+describe('kompendium-toc', () => {
+    afterEach(() => {
+        window.location.hash = '';
+    });
+
+    it('renders nothing actionable when there are no entries', async () => {
+        const page = await newSpecPage({
+            components: [Toc],
+            template: () => <kompendium-toc entries={[]} />,
+        });
+
+        expect(
+            page.root.shadowRoot.querySelector('.toc.hidden'),
+        ).not.toBeNull();
+        expect(page.root.shadowRoot.querySelector('.fab')).toBeNull();
+    });
+
+    it('expands the section containing the active anchor', async () => {
+        const page = await newSpecPage({
+            components: [Toc],
+            template: () => <kompendium-toc entries={tree} />,
+        });
+
+        // The `properties` section is collapsed by default.
+        const propertiesToggle = () =>
+            Array.from(page.root.shadowRoot.querySelectorAll('.toggle')).find(
+                (toggle) =>
+                    toggle.getAttribute('aria-label')?.includes('Properties'),
+            );
+        expect(propertiesToggle()?.getAttribute('aria-expanded')).toEqual(
+            'false',
+        );
+
+        // Navigating to an anchor nested under it should auto-expand it.
+        window.location.hash = '#/component/my-component#properties-value';
+        window.dispatchEvent(new Event('hashchange'));
+        await page.waitForChanges();
+
+        expect(propertiesToggle()?.getAttribute('aria-expanded')).toEqual(
+            'true',
+        );
+    });
+
+    it('prunes user toggles for entries that no longer exist', async () => {
+        const page = await newSpecPage({
+            components: [Toc],
+            template: () => <kompendium-toc entries={tree} />,
+        });
+        const toc = page.rootInstance as Toc;
+
+        // Simulate a user override on the properties section.
+        (toc as any).userToggles = new Map([['properties', true]]);
+
+        // Replace the entries with a tree that no longer has `properties`.
+        (toc as any).onEntriesChange([tree[0]]);
+
+        expect((toc as any).userToggles.has('properties')).toBe(false);
+    });
+});

--- a/src/components/toc/toc.tree.ts
+++ b/src/components/toc/toc.tree.ts
@@ -1,0 +1,58 @@
+import { TocEntry } from './toc.types';
+
+/**
+ * Tree helpers for navigating a (possibly nested) list of TocEntry nodes.
+ * Kept in a separate module from the kompendium-toc component so they can be
+ * unit-tested directly -- Stencil only allows a component module to export the
+ * component class itself.
+ */
+
+export function collectIds(
+    entries: TocEntry[],
+    acc: Set<string> = new Set(),
+): Set<string> {
+    for (const entry of entries) {
+        acc.add(entry.id);
+        collectIds(entry.children || [], acc);
+    }
+
+    return acc;
+}
+
+export function findEntryById(
+    id: string,
+    entries: TocEntry[],
+): TocEntry | null {
+    for (const entry of entries) {
+        if (entry.id === id) {
+            return entry;
+        }
+
+        const deeper = findEntryById(id, entry.children || []);
+        if (deeper) {
+            return deeper;
+        }
+    }
+
+    return null;
+}
+
+export function findAncestorsOf(
+    targetId: string,
+    entries: TocEntry[],
+    trail: TocEntry[] = [],
+): TocEntry[] {
+    for (const entry of entries) {
+        const children = entry.children || [];
+        if (children.some((child) => child.id === targetId)) {
+            return [...trail, entry];
+        }
+
+        const deeper = findAncestorsOf(targetId, children, [...trail, entry]);
+        if (deeper.length) {
+            return deeper;
+        }
+    }
+
+    return [];
+}

--- a/src/components/toc/toc.tsx
+++ b/src/components/toc/toc.tsx
@@ -1,0 +1,269 @@
+import { Component, Element, h, Prop, State, Watch } from '@stencil/core';
+import { TocEntry } from './toc.types';
+import { anchorHref } from '../component/anchors';
+import { getAnchorId } from '../anchor-scroll';
+import { collectIds, findAncestorsOf, findEntryById } from './toc.tree';
+
+/**
+ * Floating table-of-contents menu. Clicking the button reveals an overlay
+ * listing the entries. Selecting an entry updates the URL hash with a slug
+ * anchor (e.g. `#/component/my-component#basic-example`) so the page can
+ * scroll to the target and the location can be shared.
+ * @private
+ */
+@Component({
+    tag: 'kompendium-toc',
+    styleUrl: 'toc.scss',
+    shadow: true,
+})
+export class Toc {
+    /**
+     * Entries to show in the menu. A flat or nested list of links.
+     */
+    @Prop()
+    public entries: TocEntry[] = [];
+
+    @State()
+    private open = false;
+
+    @State()
+    private userToggles = new Map<string, boolean>();
+
+    @Element()
+    private host: HTMLKompendiumTocElement;
+
+    constructor() {
+        this.handleKeydown = this.handleKeydown.bind(this);
+        this.handleHashChange = this.handleHashChange.bind(this);
+    }
+
+    public connectedCallback(): void {
+        document.addEventListener('keydown', this.handleKeydown);
+        window.addEventListener('hashchange', this.handleHashChange);
+        this.expandSectionForActiveAnchor();
+    }
+
+    public disconnectedCallback(): void {
+        document.removeEventListener('keydown', this.handleKeydown);
+        window.removeEventListener('hashchange', this.handleHashChange);
+    }
+
+    @Watch('entries')
+    protected onEntriesChange(newEntries: TocEntry[]): void {
+        const validIds = collectIds(newEntries || []);
+        const pruned = new Map<string, boolean>();
+        for (const [id, value] of this.userToggles) {
+            if (validIds.has(id)) {
+                pruned.set(id, value);
+            }
+        }
+
+        this.userToggles = pruned;
+        this.expandSectionForActiveAnchor();
+    }
+
+    @Watch('open')
+    protected onOpenChange(isOpen: boolean, wasOpen: boolean): void {
+        if (isOpen === wasOpen) {
+            return;
+        }
+
+        const shadow = this.host.shadowRoot;
+        if (!shadow) {
+            return;
+        }
+
+        if (isOpen) {
+            requestAnimationFrame(() => {
+                const first =
+                    shadow.querySelector<HTMLElement>('.panel .link') ||
+                    shadow.querySelector<HTMLElement>(
+                        '.panel a, .panel button',
+                    );
+                first?.focus();
+            });
+        } else {
+            const fab = shadow.querySelector<HTMLElement>('.fab');
+            fab?.focus();
+        }
+    }
+
+    public render(): HTMLElement {
+        if (!this.entries || !this.entries.length) {
+            return <div class="toc hidden"></div>;
+        }
+
+        return (
+            <div class={{ toc: true, open: this.open }}>
+                <div
+                    class="scrim"
+                    onClick={this.close}
+                    aria-hidden="true"
+                ></div>
+                <div
+                    class="panel"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Table of contents"
+                    onClick={stopPropagation}
+                >
+                    <h2 class="heading">On this page</h2>
+                    <ul class="entries">
+                        {this.entries.map(this.renderEntry)}
+                    </ul>
+                </div>
+                <button
+                    type="button"
+                    class="fab"
+                    onClick={this.toggle}
+                    aria-label="Table of contents"
+                    aria-expanded={this.open ? 'true' : 'false'}
+                >
+                    {this.open ? renderCloseIcon() : renderMenuIcon()}
+                </button>
+            </div>
+        );
+    }
+
+    private renderEntry = (entry: TocEntry): HTMLElement => {
+        const children = entry.children || [];
+        const hasChildren = children.length > 0;
+        const collapsible = !!entry.collapsible && hasChildren;
+        const expanded = collapsible ? this.isEntryExpanded(entry) : true;
+
+        return (
+            <li class={{ entry: true, collapsible: collapsible }}>
+                <div class="entry-row">
+                    {collapsible ? (
+                        <button
+                            type="button"
+                            class={{ toggle: true, expanded: expanded }}
+                            onClick={this.toggleExpanded(entry.id)}
+                            aria-expanded={expanded ? 'true' : 'false'}
+                            aria-label={`Toggle ${entry.title}`}
+                        >
+                            {renderChevron()}
+                        </button>
+                    ) : null}
+                    <a
+                        class="link"
+                        href={anchorHref(entry.id)}
+                        onClick={this.handleLinkClick}
+                    >
+                        {entry.title}
+                    </a>
+                </div>
+                {hasChildren && expanded ? (
+                    <ul class="children">{children.map(this.renderEntry)}</ul>
+                ) : null}
+            </li>
+        );
+    };
+
+    private toggle = (): void => {
+        this.open = !this.open;
+    };
+
+    private close = (): void => {
+        this.open = false;
+    };
+
+    private handleLinkClick = (event: MouseEvent): void => {
+        if (
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.altKey ||
+            event.button !== 0
+        ) {
+            return;
+        }
+
+        this.close();
+    };
+
+    private toggleExpanded =
+        (id: string) =>
+        (event: MouseEvent): void => {
+            event.preventDefault();
+            event.stopPropagation();
+            const entry = findEntryById(id, this.entries);
+            const current = entry ? this.isEntryExpanded(entry) : false;
+            const next = new Map(this.userToggles);
+            next.set(id, !current);
+            this.userToggles = next;
+        };
+
+    private isEntryExpanded(entry: TocEntry): boolean {
+        const explicit = this.userToggles.get(entry.id);
+        if (explicit !== undefined) {
+            return explicit;
+        }
+
+        return !!entry.defaultExpanded;
+    }
+
+    private handleKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Escape' && this.open) {
+            this.open = false;
+        }
+    }
+
+    private handleHashChange(): void {
+        this.expandSectionForActiveAnchor();
+    }
+
+    private expandSectionForActiveAnchor(): void {
+        const activeId = getAnchorId();
+        if (!activeId) {
+            return;
+        }
+
+        const ancestors = findAncestorsOf(activeId, this.entries).filter(
+            (entry) => entry.collapsible,
+        );
+        if (!ancestors.length) {
+            return;
+        }
+
+        const next = new Map(this.userToggles);
+        let changed = false;
+        for (const ancestor of ancestors) {
+            if (!this.isEntryExpanded(ancestor)) {
+                next.set(ancestor.id, true);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            this.userToggles = next;
+        }
+    }
+}
+
+const stopPropagation = (event: MouseEvent): void => {
+    event.stopPropagation();
+};
+
+const icon = (d: string, size = 24): HTMLElement => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width={String(size)}
+        height={String(size)}
+        aria-hidden="true"
+    >
+        <path fill="currentColor" d={d} />
+    </svg>
+);
+
+const renderMenuIcon = () =>
+    icon('M3 4h18v2H3V4zm0 7h12v2H3v-2zm0 7h18v2H3v-2z');
+
+const renderCloseIcon = () =>
+    icon(
+        'M18.3 5.71 12 12l6.3 6.29-1.41 1.42L10.58 13.4l-6.29 6.3-1.42-1.41L9.17 12 2.87 5.71 4.29 4.3l6.29 6.3 6.3-6.3z',
+    );
+
+const renderChevron = () =>
+    icon('M8.59 16.34 13.17 11.75 8.59 7.17 10 5.75l6 6-6 6z', 16);

--- a/src/components/toc/toc.types.ts
+++ b/src/components/toc/toc.types.ts
@@ -1,0 +1,17 @@
+export interface TocEntry {
+    id: string;
+    title: string;
+    children?: TocEntry[];
+
+    /**
+     * When true, the entry's children are hidden behind an expand/collapse
+     * toggle in the table of contents. Defaults to false.
+     */
+    collapsible?: boolean;
+
+    /**
+     * When true, a collapsible entry starts expanded. The user can still
+     * collapse it manually. Ignored when `collapsible` is false.
+     */
+    defaultExpanded?: boolean;
+}

--- a/src/style/global-layout-rules.scss
+++ b/src/style/global-layout-rules.scss
@@ -11,6 +11,11 @@ kompendium-playground {
     margin: functions.pxToRem(40) 0 functions.pxToRem(20) 0;
     border-top: 1px solid rgb(var(--kompendium-contrast-500));
 
+    // The section headings are h2 elements for the sake of the document
+    // outline, but are sized like h3 headings by design.
+    font-size: functions.pxToRem(22);
+    line-height: functions.pxToRem(24);
+
     &:before {
         content: '';
         width: functions.pxToRem(2);


### PR DESCRIPTION
Re-open of https://github.com/jgroth/kompendium/pull/179

Based on https://github.com/jgroth/kompendium/pull/185, so that needs merging first (or it will be included when this PR is merged — see first commit).

fix: #165 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added table of contents component with collapsible sections for easier navigation within documentation
  * Implemented anchor links throughout component documentation, enabling direct linking to specific sections
  * Improved example documentation display with better title and description formatting

* **Style**
  * Enhanced typography consistency across headings in documentation sections

* **Tests**
  * Added comprehensive test coverage for anchoring, navigation, and documentation utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->